### PR TITLE
UF-10786 - Update Intric access-token client

### DIFF
--- a/src/main/java/se/sundsvall/ai/flow/integration/intric/IntricTokenService.java
+++ b/src/main/java/se/sundsvall/ai/flow/integration/intric/IntricTokenService.java
@@ -40,7 +40,7 @@ class IntricTokenService {
 			.build();
 
 		accessTokenRequestData = new LinkedMultiValueMap<>();
-		accessTokenRequestData.add("grant_type", "");
+		accessTokenRequestData.add("grant_type", "password");
 		accessTokenRequestData.add("username", properties.oauth2().username());
 		accessTokenRequestData.add("password", properties.oauth2().password());
 		accessTokenRequestData.add("scope", "");


### PR DESCRIPTION
Explicitly set OAuth2 grant type to "password" in the Intric access-token client, due to an updated Intric dependency (FastAPI) that previously required it to be empty

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
