### PR TITLE
HYDRAN-2161: update Eneo API spec and adapt integration to v1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,12 +117,14 @@
 				<executions>
 					<execution>
 						<!--
-							Note: if the OpenAPI spec is updated, any instances of the string " " that exists
-							in a number of places must be removed, due to a bug in the OpenAPI generator that makes it
-							generate uncompilable code - https://github.com/OpenAPITools/openapi-generator/issues/19391
+							The Eneo OpenAPI spec contains 400+ schemas, but we only consume a handful. Generating
+							the full set produces uncompilable Java (e.g. complex object defaults on $ref properties),
+							so we restrict generation via <modelsToGenerate> to the schemas actually used by EneoClient,
+							EneoIntegration and EneoMapper.
 
-							Also, alongside the input spec below there is an unmodified version of it, to be able to
-							determine which changes have been done to make it play nice with the OpenAPI generator.
+							Schemas referenced (transitively) by those generated models but not used by us are mapped
+							to java.lang.Object via <schemaMappings>/<typeMappings> so the generator emits a valid
+							import instead of dangling references to non-generated classes.
 						-->
 						<id>eneo-api</id>
 						<goals>
@@ -130,6 +132,9 @@
 						</goals>
 						<configuration>
 							<inputSpec>src/main/resources/integrations/eneo.yml</inputSpec>
+							<modelsToGenerate>AppRunPublic,AskAssistant,AskResponse,FilePublic,ModelId,RunAppRequest,RunService,ServiceOutput,Status</modelsToGenerate>
+							<schemaMappings>UseTools=java.lang.Object,InfoBlobAskAssistantPublic=java.lang.Object,WebSearchResultPublic=java.lang.Object,CompletionModelPublic=java.lang.Object,AppRunInput=java.lang.Object,UserSparse=java.lang.Object</schemaMappings>
+							<typeMappings>UseTools=Object,InfoBlobAskAssistantPublic=Object,WebSearchResultPublic=Object,CompletionModelPublic=Object,AppRunInput=Object,UserSparse=Object</typeMappings>
 							<configOptions>
 								<modelPackage>generated.eneo.ai</modelPackage>
 								<!--

--- a/src/main/java/se/sundsvall/ai/flow/integration/eneo/EneoMapper.java
+++ b/src/main/java/se/sundsvall/ai/flow/integration/eneo/EneoMapper.java
@@ -1,5 +1,7 @@
 package se.sundsvall.ai.flow.integration.eneo;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import generated.eneo.ai.AppRunPublic;
 import generated.eneo.ai.AskAssistant;
 import generated.eneo.ai.AskResponse;
@@ -9,9 +11,17 @@ import generated.eneo.ai.RunService;
 import generated.eneo.ai.ServiceOutput;
 import java.util.List;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.sundsvall.ai.flow.integration.eneo.model.Response;
+import se.sundsvall.dept44.problem.Problem;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 public final class EneoMapper {
+
+	private static final Logger LOG = LoggerFactory.getLogger(EneoMapper.class);
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	private EneoMapper() {
 		// Prevent instantiation
@@ -20,32 +30,46 @@ public final class EneoMapper {
 	public static RunService toRunService(final String input, final List<UUID> uploadedInputFilesInUse) {
 		return new RunService()
 			.input(input)
-			.files(toModelIds(uploadedInputFilesInUse));
-	}
-
-	public static List<ModelId> toModelIds(final List<UUID> ids) {
-		return ids.stream()
-			.map(id -> new ModelId().id(id))
-			.toList();
+			.files(uploadedInputFilesInUse);
 	}
 
 	public static AskAssistant toAskAssistant(final String question, final List<UUID> uploadedInputFilesInUse) {
 		return new AskAssistant()
 			.question(question)
-			.files(toModelIds(uploadedInputFilesInUse));
+			.files(uploadedInputFilesInUse);
 	}
 
 	public static RunAppRequest toRunAppRequest(final List<UUID> uploadedInputFilesInUse) {
 		return new RunAppRequest()
-			.files(toModelIds(uploadedInputFilesInUse));
+			.files(uploadedInputFilesInUse.stream()
+				.map(id -> new ModelId().id(id))
+				.toList());
 	}
 
 	public static Response toResponse(final AskResponse askResponse) {
 		return new Response(askResponse.getSessionId(), askResponse.getAnswer());
 	}
 
+	/**
+	 * The {@code ServiceOutput.output} field is a polymorphic value whose runtime type depends on
+	 * the Eneo service's configured output format (string, json, list, boolean). Non-String values
+	 * are serialized to their JSON representation so downstream consumers always see a String.
+	 */
 	public static Response toResponse(final ServiceOutput serviceOutput) {
-		return new Response(serviceOutput.getOutput());
+		final var output = serviceOutput.getOutput();
+		final var outputAsString = switch (output) {
+			case String s -> s;
+			case null -> null;
+			default -> {
+				try {
+					yield OBJECT_MAPPER.writeValueAsString(output);
+				} catch (final JsonProcessingException e) {
+					LOG.error("Failed to serialize ServiceOutput of type {} to JSON string. Value: {}", output.getClass().getName(), output, e);
+					throw Problem.valueOf(INTERNAL_SERVER_ERROR, "Failed to serialize ServiceOutput to JSON string");
+				}
+			}
+		};
+		return new Response(outputAsString);
 	}
 
 	// Response for APP run

--- a/src/main/resources/integrations/eneo.yml
+++ b/src/main/resources/integrations/eneo.yml
@@ -2,43 +2,48 @@ openapi: 3.1.0
 info:
   title: Eneo-Sundsvall
   description: General AI framework
-  version: '1.0'
+  version: '1.2'
 servers:
-  - url: https://api-i-test.sundsvall.se/eneo-sundsvall/1.0
-security:
-  - default: []
+  - url: 'https://eneo-test.sundsvall.se/api/v1'
 tags:
   - name: users
     description: User operations. **Login** logic is here.
   - name: user-groups
     description: User groups operations. Use this to manage user groups.
   - name: info-blobs
-    description: Document operations. **Info-blobs** are blobs of binary information,
-      not restricted to text, although current support is only text.
+    description: >-
+      Document operations. **Info-blobs** are blobs of binary information, not
+      restricted to text, although current support is only text.
   - name: groups
-    description: Group operations. Use this to organize your info-blobs. **Uploading**
+    description: >-
+      Group operations. Use this to organize your info-blobs. **Uploading**
       info-blobs is here.
   - name: assistants
-    description: Assistant operations. Create assistants with the desired configuration
-      and ask questions to them.
+    description: >-
+      Assistant operations. Create assistants with the desired configuration and
+      ask questions to them.
   - name: services
     description: Services operations. Documentation for these endpoints are coming soon.
     externalDocs:
       description: Services documentation (coming soon)
-      url: https://www.eneo.ai/
+      url: 'https://www.eneo.ai/'
   - name: jobs
     description: Job operations. Use this to keep track of running and completed jobs.
   - name: logging
-    description: Logging operations. Use these endpoints to get exactly what was sent
-      to the AI-model for each question.
+    description: >-
+      Logging operations. Use these endpoints to get exactly what was sent to
+      the AI-model for each question.
   - name: analysis
-    description: Analysis operations. Use these endpoints to see how your assistants
-      are used, as well as to ask questions about the questions asked to an assistant.
+    description: >-
+      Analysis operations. Use these endpoints to see how your assistants are
+      used, as well as to ask questions about the questions asked to an
+      assistant.
   - name: widgets
     description: Widget operations. Use this to save widget settings and run widgets.
   - name: allowed-origins
-    description: Allowed Origins operations. Use this to specify the allowed origins
-      from where the widgets will be hosted
+    description: >-
+      Allowed Origins operations. Use this to specify the allowed origins from
+      where the widgets will be hosted
   - name: crawls
     description: Crawl operations. Use these endpoint to set up and run crawls.
   - name: crawl-runs
@@ -46,21 +51,26 @@ tags:
   - name: roles
     description: User roles. Use this to manage user permissions.
   - name: admin
-    description: Tenant Admin operations. Manage users, settings, and resources within
-      your specific tenant/organization. Requires admin account API key for your tenant.
-      For system-wide administration across all tenants, see Sysadmin endpoints.
+    description: >-
+      Tenant Admin operations. Manage users, settings, and resources within your
+      specific tenant/organization. Requires admin account API key for your
+      tenant. For system-wide administration across all tenants, see Sysadmin
+      endpoints.
   - name: settings
     description: Settings operations. Currently only houses chatbot widget settings.
   - name: sysadmin
-    description: System Administration operations. Manage the entire Eneo installation
-      across all tenants using the INTRIC_SUPER_API_KEY environment variable. Create/manage
-      tenants, system-wide settings, and cross-tenant operations. For single tenant
-      management (users, settings within your organization), see Tenant Admin endpoints.
+    description: >-
+      System Administration operations. Manage the entire Eneo installation
+      across all tenants using the INTRIC_SUPER_API_KEY environment variable.
+      Create/manage tenants, system-wide settings, and cross-tenant operations.
+      For single tenant management (users, settings within your organization),
+      see Tenant Admin endpoints.
   - name: modules
-    description: Module operations. These endpoints are used to handle module access
-      for tenants. Requires elevated privileges.
+    description: >-
+      Module operations. These endpoints are used to handle module access for
+      tenants. Requires elevated privileges.
 paths:
-  "/crawl-runs/{id}/":
+  '/crawl-runs/{id}/':
     get:
       tags:
         - crawl-runs
@@ -69,12 +79,14 @@ paths:
       parameters:
         - name: id
           in: path
+          description: Unique identifier of the crawl run to retrieve
           required: true
           style: simple
           explode: false
           schema:
             type: string
             format: uuid
+            description: Unique identifier of the crawl run to retrieve
             title: Id
       responses:
         '200':
@@ -82,26 +94,31 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/intric__websites__crawl_dependencies__crawl_models__CrawlRunPublic"
+                $ref: >-
+                  #/components/schemas/intric__websites__crawl_dependencies__crawl_models__CrawlRunPublic
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/apps/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/apps/{id}/':
     get:
       tags:
         - apps
@@ -123,31 +140,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AppPublic"
+                $ref: '#/components/schemas/AppPublic'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - apps
@@ -171,25 +192,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     patch:
       tags:
         - apps
@@ -209,7 +234,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/AppUpdateRequest"
+              $ref: '#/components/schemas/AppUpdateRequest'
         required: true
       responses:
         '200':
@@ -217,38 +242,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AppPublic"
+                $ref: '#/components/schemas/AppPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/apps/{id}/runs/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/apps/{id}/runs/':
     get:
       tags:
         - apps
@@ -270,37 +299,41 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_AppRunSparse_"
+                $ref: '#/components/schemas/PaginatedResponse_AppRunSparse_'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - apps
@@ -320,7 +353,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/RunAppRequest"
+              $ref: '#/components/schemas/RunAppRequest'
         required: true
       responses:
         '203':
@@ -328,32 +361,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AppRunPublic"
+                $ref: '#/components/schemas/AppRunPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/apps/{id}/prompts/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/apps/{id}/prompts/':
     get:
       tags:
         - apps
@@ -375,32 +412,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_PromptSparse_"
+                $ref: '#/components/schemas/PaginatedResponse_PromptSparse_'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/apps/{id}/publish/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/apps/{id}/publish/':
     post:
       tags:
         - apps
@@ -430,32 +471,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AppPublic"
+                $ref: '#/components/schemas/AppPublic'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/app-runs/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/app-runs/{id}/':
     get:
       tags:
         - app-runs
@@ -477,31 +522,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AppRunPublic"
+                $ref: '#/components/schemas/AppRunPublic'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - app-runs
@@ -525,37 +574,41 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/users/login/token/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /users/login/token/:
     post:
       tags:
         - users
       summary: Login
-      description: OAuth2 Login
+      description: OAuth2 Login with comprehensive error handling and logging
       operationId: Login_api_v1_users_login_token__post
       requestBody:
         content:
           application/x-www-form-urlencoded:
             schema:
-              "$ref": "#/components/schemas/Body_Login_api_v1_users_login_token__post"
+              $ref: '#/components/schemas/Body_Login_api_v1_users_login_token__post'
         required: true
       responses:
         '200':
@@ -563,35 +616,40 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AccessToken"
+                $ref: '#/components/schemas/AccessToken'
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/users/login/openid-connect/mobilityguard/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /users/login/openid-connect/mobilityguard/:
     post:
       tags:
         - users
       summary: Login With Mobilityguard
-      description: OpenID Connect Login with mobilityguard.
-      operationId: login_with_mobilityguard_api_v1_users_login_openid_connect_mobilityguard__post
+      description: OpenID Connect Login (generic OIDC provider).
+      operationId: >-
+        login_with_mobilityguard_api_v1_users_login_openid_connect_mobilityguard__post
       requestBody:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/OpenIdConnectLogin"
+              $ref: '#/components/schemas/OpenIdConnectLogin'
         required: true
       responses:
         '200':
@@ -599,18 +657,22 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AccessToken"
+                $ref: '#/components/schemas/AccessToken'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/users/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /users/:
     get:
       tags:
         - users
@@ -671,20 +733,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/CursorPaginatedResponse_UserSparse_"
+                $ref: '#/components/schemas/CursorPaginatedResponse_UserSparse_'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/users/me/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /users/me/:
     get:
       tags:
         - users
@@ -696,20 +762,23 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserPublic"
+                $ref: '#/components/schemas/UserPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
       security:
         - OAuth2PasswordBearer: []
-        - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/users/api-keys/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /users/api-keys/:
     get:
       tags:
         - users
@@ -725,14 +794,17 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/ApiKey"
+                $ref: '#/components/schemas/ApiKey'
       security:
         - OAuth2PasswordBearer: []
-        - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/users/tenant/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /users/tenant/:
     get:
       tags:
         - users
@@ -744,20 +816,23 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/TenantPublic"
+                $ref: '#/components/schemas/TenantPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
       security:
         - OAuth2PasswordBearer: []
-        - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/users/admin/invite/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /users/admin/invite/:
     post:
       tags:
         - users
@@ -767,7 +842,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/PropUserInvite"
+              $ref: '#/components/schemas/PropUserInvite'
         required: true
       responses:
         '201':
@@ -775,20 +850,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserAdminView"
+                $ref: '#/components/schemas/UserAdminView'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/users/admin/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/users/admin/{id}/':
     delete:
       tags:
         - users
@@ -812,13 +891,17 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     patch:
       tags:
         - users
@@ -838,7 +921,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/PartialPropUserUpdate"
+              $ref: '#/components/schemas/PartialPropUserUpdate'
         required: true
       responses:
         '200':
@@ -846,20 +929,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserAdminView"
+                $ref: '#/components/schemas/UserAdminView'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/users/provision/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /users/provision/:
     post:
       tags:
         - users
@@ -869,7 +956,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/UserProvision"
+              $ref: '#/components/schemas/UserProvision'
         required: true
       responses:
         '201':
@@ -882,18 +969,22 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/info-blobs/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /info-blobs/:
     get:
       tags:
         - info-blobs
@@ -909,14 +1000,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_InfoBlobPublicNoText_"
+                $ref: '#/components/schemas/PaginatedResponse_InfoBlobPublicNoText_'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/info-blobs/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/info-blobs/{id}/':
     get:
       tags:
         - info-blobs
@@ -937,25 +1032,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/InfoBlobPublic"
+                $ref: '#/components/schemas/InfoBlobPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - info-blobs
@@ -975,7 +1074,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/InfoBlobUpdatePublic"
+              $ref: '#/components/schemas/InfoBlobUpdatePublic'
         required: true
       responses:
         '200':
@@ -983,25 +1082,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/InfoBlobPublic"
+                $ref: '#/components/schemas/InfoBlobPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - info-blobs
@@ -1023,26 +1126,68 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/InfoBlobPublic"
+                $ref: '#/components/schemas/InfoBlobPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/groups/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/info-blobs/spaces/{space_id}/info-blobs/':
+    get:
+      tags:
+        - info-blobs
+      summary: Get Space Info Blobs
+      operationId: get_space_info_blobs_api_v1_info_blobs_spaces__space_id__info_blobs__get
+      parameters:
+        - name: space_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            title: Space Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResponse_InfoBlobPublicNoText_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /groups/:
     get:
       tags:
         - groups
@@ -1054,7 +1199,8 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_GroupPublicWithMetadata_"
+                $ref: >-
+                  #/components/schemas/PaginatedResponse_GroupPublicWithMetadata_
       deprecated: true
       security:
         - OAuth2PasswordBearer: []
@@ -1062,19 +1208,25 @@ paths:
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - groups
       summary: Create Group
-      description: |-
-        Valid values for `embedding_model` are the provided by `GET /api/v1/settings/models/`.
+      description: >-
+        Valid values for `embedding_model` are the provided by `GET
+        /api/v1/settings/models/`.
+
         Use the `name` field of the response from this endpoint.
       operationId: create_group_api_v1_groups__post
       requestBody:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/CreateGroupRequest"
+              $ref: '#/components/schemas/CreateGroupRequest'
         required: true
       responses:
         '200':
@@ -1082,13 +1234,13 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GroupPublicWithMetadata"
+                $ref: '#/components/schemas/GroupPublicWithMetadata'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       deprecated: true
       security:
         - OAuth2PasswordBearer: []
@@ -1096,7 +1248,11 @@ paths:
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/groups/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/groups/{id}/':
     get:
       tags:
         - groups
@@ -1118,25 +1274,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/CollectionPublic"
+                $ref: '#/components/schemas/CollectionPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - groups
@@ -1156,7 +1316,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/CollectionUpdate"
+              $ref: '#/components/schemas/CollectionUpdate'
         required: true
       responses:
         '200':
@@ -1164,25 +1324,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/CollectionPublic"
+                $ref: '#/components/schemas/CollectionPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - groups
@@ -1199,27 +1363,34 @@ paths:
             format: uuid
             title: Id
       responses:
-        '204':
+        '200':
           description: Successful Response
+          content:
+            application/json:
+              schema: {}
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/groups/{id}/info-blobs/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/groups/{id}/info-blobs/':
     get:
       tags:
         - groups
@@ -1241,31 +1412,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_InfoBlobPublicNoText_"
+                $ref: '#/components/schemas/PaginatedResponse_InfoBlobPublicNoText_'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - groups
@@ -1289,7 +1464,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/InfoBlobUpsertRequest"
+              $ref: '#/components/schemas/InfoBlobUpsertRequest'
         required: true
       responses:
         '200':
@@ -1297,49 +1472,53 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_InfoBlobPublic_"
+                $ref: '#/components/schemas/PaginatedResponse_InfoBlobPublic_'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
         '503':
           description: Service Unavailable
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/groups/{id}/info-blobs/upload/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/groups/{id}/info-blobs/upload/':
     post:
       tags:
         - groups
       summary: Upload File
-      description: Starts a job, use the job operations to keep track of this job
+      description: 'Starts a job, use the job operations to keep track of this job'
       operationId: upload_file_api_v1_groups__id__info_blobs_upload__post
       parameters:
         - name: id
@@ -1355,7 +1534,8 @@ paths:
         content:
           multipart/form-data:
             schema:
-              "$ref": "#/components/schemas/Body_upload_file_api_v1_groups__id__info_blobs_upload__post"
+              $ref: >-
+                #/components/schemas/Body_upload_file_api_v1_groups__id__info_blobs_upload__post
         required: true
       responses:
         '202':
@@ -1363,20 +1543,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/JobPublic"
+                $ref: '#/components/schemas/JobPublic'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/groups/{id}/searches/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/groups/{id}/searches/':
     post:
       tags:
         - groups
@@ -1396,7 +1580,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SemanticSearchRequest"
+              $ref: '#/components/schemas/SemanticSearchRequest'
         required: true
       responses:
         '200':
@@ -1404,20 +1588,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_SemanticSearchResponse_"
+                $ref: '#/components/schemas/PaginatedResponse_SemanticSearchResponse_'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/groups/{id}/transfer/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/groups/{id}/transfer/':
     post:
       tags:
         - groups
@@ -1437,7 +1625,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/TransferRequest"
+              $ref: '#/components/schemas/TransferRequest'
         required: true
       responses:
         '204':
@@ -1447,14 +1635,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/settings/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /settings/:
     get:
       tags:
         - settings
@@ -1466,13 +1658,17 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SettingsPublic"
+                $ref: '#/components/schemas/SettingsPublic'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - settings
@@ -1483,7 +1679,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SettingsPublic"
+              $ref: '#/components/schemas/SettingsPublic'
         required: true
       responses:
         '200':
@@ -1491,20 +1687,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SettingsPublic"
+                $ref: '#/components/schemas/SettingsPublic'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/settings/models/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /settings/models/:
     get:
       tags:
         - settings
@@ -1522,14 +1722,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GetModelsResponse"
+                $ref: '#/components/schemas/GetModelsResponse'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/settings/formats/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /settings/formats/:
     get:
       tags:
         - settings
@@ -1541,14 +1745,218 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_str_"
+                $ref: '#/components/schemas/PaginatedResponse_str_'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /settings/templates:
+    patch:
+      tags:
+        - settings
+      summary: Toggle template feature
+      description: |-
+        Enable or disable the template management feature for your tenant.
+
+        **Admin Only:** Requires admin permissions.
+
+        **Behavior:**
+        - Updates the `using_templates` feature flag for your tenant
+        - When disabled: Template gallery returns empty list (not error)
+        - When enabled: Users can see and use tenant templates
+        - Change takes effect immediately (no reload required)
+
+        **Example Request:**
+        ```json
+        {
+          "enabled": true
+        }
+        ```
+
+        **Example Response:**
+        ```json
+        {
+          "chatbot_widget": {},
+          "using_templates": true
+        }
+        ```
+      operationId: update_template_setting_api_v1_settings_templates_patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TemplateSettingUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettingsPublic'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/assistants/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /settings/audit-logging:
+    patch:
+      tags:
+        - settings
+      summary: Toggle global audit logging
+      description: >-
+        Enable or disable global audit logging for your tenant.
+
+
+        **Admin Only:** Requires admin permissions.
+
+
+        **Behavior:**
+
+        - Updates the `audit_logging_enabled` feature flag for your tenant
+
+        - When disabled: No audit logs are created for any action (global kill
+        switch)
+
+        - When enabled: Audit logging resumes with category and action-level
+        filtering
+
+        - This is independent from category/action configuration
+
+        - Change takes effect immediately for all workers
+
+
+        **Example Request:**
+
+        ```json
+
+        {
+          "enabled": false
+        }
+
+        ```
+
+
+        **Example Response:**
+
+        ```json
+
+        {
+          "chatbot_widget": {},
+          "audit_logging_enabled": false,
+          "using_templates": true
+        }
+
+        ```
+      operationId: update_audit_logging_setting_api_v1_settings_audit_logging_patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TemplateSettingUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettingsPublic'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /settings/provisioning:
+    patch:
+      tags:
+        - settings
+      summary: Toggle JIT user provisioning
+      description: |-
+        Enable or disable JIT (Just-In-Time) user provisioning for your tenant.
+
+        **Admin Only:** Requires admin permissions.
+
+        **Behavior:**
+        - When enabled: Users are automatically created on first SSO login
+        - When disabled: Only pre-existing users can log in via SSO
+        - New users get the "User" role by default
+        - Change takes effect immediately for all SSO logins
+
+        **Example Request:**
+        ```json
+        {
+          "enabled": true
+        }
+        ```
+
+        **Example Response:**
+        ```json
+        {
+          "chatbot_widget": {},
+          "using_templates": true,
+          "audit_logging_enabled": true,
+          "provisioning": true
+        }
+        ```
+      operationId: update_provisioning_setting_api_v1_settings_provisioning_patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TemplateSettingUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettingsPublic'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /assistants/:
     get:
       tags:
         - assistants
@@ -1579,19 +1987,23 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_AssistantPublic_"
+                $ref: '#/components/schemas/PaginatedResponse_AssistantPublic_'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - assistants
@@ -1601,7 +2013,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/AssistantCreatePublic"
+              $ref: '#/components/schemas/AssistantCreatePublic'
         required: true
       responses:
         '200':
@@ -1609,19 +2021,19 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AssistantPublic"
+                $ref: '#/components/schemas/AssistantPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       deprecated: true
       security:
         - OAuth2PasswordBearer: []
@@ -1629,7 +2041,11 @@ paths:
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/assistants/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/assistants/{id}/':
     get:
       tags:
         - assistants
@@ -1651,31 +2067,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AssistantPublic"
+                $ref: '#/components/schemas/AssistantPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - assistants
@@ -1696,7 +2116,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/PartialAssistantUpdatePublic"
+              $ref: '#/components/schemas/PartialAssistantUpdatePublic'
         required: true
       responses:
         '200':
@@ -1704,31 +2124,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AssistantPublic"
+                $ref: '#/components/schemas/AssistantPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - assistants
@@ -1752,26 +2176,30 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/assistants/{id}/sessions/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/assistants/{id}/sessions/':
     get:
       tags:
         - assistants
@@ -1820,31 +2248,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/CursorPaginatedResponse_SessionMetadataPublic_"
+                $ref: >-
+                  #/components/schemas/CursorPaginatedResponse_SessionMetadataPublic_
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - assistants
@@ -1876,7 +2309,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/AskAssistant"
+              $ref: '#/components/schemas/AskAssistant'
         required: true
       responses:
         '200':
@@ -1884,7 +2317,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AskResponse"
+                $ref: '#/components/schemas/AskResponse'
             text/event-stream:
               schema:
                 type: object
@@ -1902,28 +2335,28 @@ paths:
                   files:
                     type: array
                     items:
-                      "$ref": "#/components/schemas/FilePublic"
+                      $ref: '#/components/schemas/FilePublic'
                     title: Files
                   generated_files:
                     type: array
                     items:
-                      "$ref": "#/components/schemas/FilePublic"
+                      $ref: '#/components/schemas/FilePublic'
                     title: Generated Files
                   references:
                     type: array
                     items:
-                      "$ref": "#/components/schemas/InfoBlobAskAssistantPublic"
+                      $ref: '#/components/schemas/InfoBlobAskAssistantPublic'
                     title: References
                   tools:
-                    "$ref": "#/components/schemas/UseTools"
+                    $ref: '#/components/schemas/UseTools'
                   web_search_references:
                     type: array
                     items:
-                      "$ref": "#/components/schemas/WebSearchResultPublic"
+                      $ref: '#/components/schemas/WebSearchResultPublic'
                     title: Web Search References
                   model:
                     anyOf:
-                      - "$ref": "#/components/schemas/CompletionModelPublic"
+                      - $ref: '#/components/schemas/CompletionModelPublic'
                       - type: 'null'
                 required:
                   - answer
@@ -1935,366 +2368,35 @@ paths:
                   - tools
                   - web_search_references
                 title: AskResponse
-                "$defs":
-                  CompletionModelPublic:
-                    properties:
-                      created_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Created At
-                      updated_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Updated At
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      name:
-                        title: Name
-                        type: string
-                      nickname:
-                        title: Nickname
-                        type: string
-                      family:
-                        "$ref": "#/components/schemas/ModelFamily"
-                      token_limit:
-                        title: Token Limit
-                        type: integer
-                      is_deprecated:
-                        title: Is Deprecated
-                        type: boolean
-                      nr_billion_parameters:
-                        anyOf:
-                          - type: integer
-                          - type: 'null'
-                        title: Nr Billion Parameters
-                      hf_link:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Hf Link
-                      stability:
-                        "$ref": "#/components/schemas/ModelStability"
-                      hosting:
-                        "$ref": "#/components/schemas/ModelHostingLocation"
-                      open_source:
-                        anyOf:
-                          - type: boolean
-                          - type: 'null'
-                        title: Open Source
-                      description:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Description
-                      deployment_name:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Deployment Name
-                      org:
-                        anyOf:
-                          - "$ref": "#/components/schemas/ModelOrg"
-                          - type: 'null'
-                      vision:
-                        title: Vision
-                        type: boolean
-                      reasoning:
-                        title: Reasoning
-                        type: boolean
-                      base_url:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Base Url
-                      litellm_model_name:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Litellm Model Name
-                      is_org_enabled:
-                        default: false
-                        title: Is Org Enabled
-                        type: boolean
-                      is_org_default:
-                        default: false
-                        title: Is Org Default
-                        type: boolean
-                      can_access:
-                        default: false
-                        title: Can Access
-                        type: boolean
-                      is_locked:
-                        default: true
-                        title: Is Locked
-                        type: boolean
-                      security_classification:
-                        anyOf:
-                          - "$ref": "#/components/schemas/SecurityClassificationPublic"
-                          - type: 'null'
-                    required:
-                      - id
-                      - name
-                      - nickname
-                      - family
-                      - token_limit
-                      - is_deprecated
-                      - stability
-                      - hosting
-                      - vision
-                      - reasoning
-                    title: CompletionModelPublic
-                    type: object
-                  FilePublic:
-                    properties:
-                      created_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Created At
-                      updated_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Updated At
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      name:
-                        title: Name
-                        type: string
-                      mimetype:
-                        title: Mimetype
-                        type: string
-                      size:
-                        title: Size
-                        type: integer
-                      transcription:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Transcription
-                    required:
-                      - id
-                      - name
-                      - mimetype
-                      - size
-                    title: FilePublic
-                    type: object
-                  InfoBlobAskAssistantPublic:
-                    properties:
-                      created_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Created At
-                      updated_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Updated At
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      metadata:
-                        "$ref": "#/components/schemas/InfoBlobMetadata"
-                      group_id:
-                        anyOf:
-                          - format: uuid
-                            type: string
-                          - type: 'null'
-                        title: Group Id
-                      website_id:
-                        anyOf:
-                          - format: uuid
-                            type: string
-                          - type: 'null'
-                        title: Website Id
-                      score:
-                        title: Score
-                        type: number
-                    required:
-                      - id
-                      - metadata
-                      - score
-                    title: InfoBlobAskAssistantPublic
-                    type: object
-                  InfoBlobMetadata:
-                    properties:
-                      url:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Url
-                      title:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Title
-                      embedding_model_id:
-                        format: uuid
-                        title: Embedding Model Id
-                        type: string
-                      size:
-                        title: Size
-                        type: integer
-                    required:
-                      - embedding_model_id
-                      - size
-                    title: InfoBlobMetadata
-                    type: object
-                  ModelFamily:
-                    enum:
-                      - openai
-                      - mistral
-                      - vllm
-                      - claude
-                      - azure
-                      - ovhcloud
-                      - e5
-                    title: ModelFamily
-                    type: string
-                  ModelHostingLocation:
-                    enum:
-                      - usa
-                      - eu
-                      - swe
-                    title: ModelHostingLocation
-                    type: string
-                  ModelOrg:
-                    enum:
-                      - OpenAI
-                      - Meta
-                      - Microsoft
-                      - Anthropic
-                      - Mistral
-                      - KBLab
-                      - Google
-                      - Berget
-                    title: ModelOrg
-                    type: string
-                  ModelStability:
-                    enum:
-                      - stable
-                      - experimental
-                    title: ModelStability
-                    type: string
-                  SecurityClassificationPublic:
-                    description: Basic security classification information.
-                    properties:
-                      created_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Created At
-                      updated_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Updated At
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      name:
-                        title: Name
-                        type: string
-                      description:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Description
-                      security_level:
-                        title: Security Level
-                        type: integer
-                    required:
-                      - id
-                      - name
-                      - description
-                      - security_level
-                    title: SecurityClassificationPublic
-                    type: object
-                  ToolAssistant:
-                    properties:
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      handle:
-                        title: Handle
-                        type: string
-                    required:
-                      - id
-                      - handle
-                    title: ToolAssistant
-                    type: object
-                  UseTools:
-                    properties:
-                      assistants:
-                        items:
-                          "$ref": "#/components/schemas/ToolAssistant"
-                        title: Assistants
-                        type: array
-                    required:
-                      - assistants
-                    title: UseTools
-                    type: object
-                  WebSearchResultPublic:
-                    properties:
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      title:
-                        title: Title
-                        type: string
-                      url:
-                        title: Url
-                        type: string
-                    required:
-                      - id
-                      - title
-                      - url
-                    title: WebSearchResultPublic
-                    type: object
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/assistants/{id}/sessions/{session_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/assistants/{id}/sessions/{session_id}/':
     get:
       tags:
         - assistants
@@ -2325,31 +2427,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SessionPublic"
+                $ref: '#/components/schemas/SessionPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - assistants
@@ -2390,7 +2496,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/AskAssistant"
+              $ref: '#/components/schemas/AskAssistant'
         required: true
       responses:
         '200':
@@ -2398,7 +2504,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AskResponse"
+                $ref: '#/components/schemas/AskResponse'
             text/event-stream:
               schema:
                 type: object
@@ -2416,28 +2522,28 @@ paths:
                   files:
                     type: array
                     items:
-                      "$ref": "#/components/schemas/FilePublic"
+                      $ref: '#/components/schemas/FilePublic'
                     title: Files
                   generated_files:
                     type: array
                     items:
-                      "$ref": "#/components/schemas/FilePublic"
+                      $ref: '#/components/schemas/FilePublic'
                     title: Generated Files
                   references:
                     type: array
                     items:
-                      "$ref": "#/components/schemas/InfoBlobAskAssistantPublic"
+                      $ref: '#/components/schemas/InfoBlobAskAssistantPublic'
                     title: References
                   tools:
-                    "$ref": "#/components/schemas/UseTools"
+                    $ref: '#/components/schemas/UseTools'
                   web_search_references:
                     type: array
                     items:
-                      "$ref": "#/components/schemas/WebSearchResultPublic"
+                      $ref: '#/components/schemas/WebSearchResultPublic'
                     title: Web Search References
                   model:
                     anyOf:
-                      - "$ref": "#/components/schemas/CompletionModelPublic"
+                      - $ref: '#/components/schemas/CompletionModelPublic'
                       - type: 'null'
                 required:
                   - answer
@@ -2449,370 +2555,40 @@ paths:
                   - tools
                   - web_search_references
                 title: AskResponse
-                "$defs":
-                  CompletionModelPublic:
-                    properties:
-                      created_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Created At
-                      updated_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Updated At
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      name:
-                        title: Name
-                        type: string
-                      nickname:
-                        title: Nickname
-                        type: string
-                      family:
-                        "$ref": "#/components/schemas/ModelFamily"
-                      token_limit:
-                        title: Token Limit
-                        type: integer
-                      is_deprecated:
-                        title: Is Deprecated
-                        type: boolean
-                      nr_billion_parameters:
-                        anyOf:
-                          - type: integer
-                          - type: 'null'
-                        title: Nr Billion Parameters
-                      hf_link:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Hf Link
-                      stability:
-                        "$ref": "#/components/schemas/ModelStability"
-                      hosting:
-                        "$ref": "#/components/schemas/ModelHostingLocation"
-                      open_source:
-                        anyOf:
-                          - type: boolean
-                          - type: 'null'
-                        title: Open Source
-                      description:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Description
-                      deployment_name:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Deployment Name
-                      org:
-                        anyOf:
-                          - "$ref": "#/components/schemas/ModelOrg"
-                          - type: 'null'
-                      vision:
-                        title: Vision
-                        type: boolean
-                      reasoning:
-                        title: Reasoning
-                        type: boolean
-                      base_url:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Base Url
-                      litellm_model_name:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Litellm Model Name
-                      is_org_enabled:
-                        default: false
-                        title: Is Org Enabled
-                        type: boolean
-                      is_org_default:
-                        default: false
-                        title: Is Org Default
-                        type: boolean
-                      can_access:
-                        default: false
-                        title: Can Access
-                        type: boolean
-                      is_locked:
-                        default: true
-                        title: Is Locked
-                        type: boolean
-                      security_classification:
-                        anyOf:
-                          - "$ref": "#/components/schemas/SecurityClassificationPublic"
-                          - type: 'null'
-                    required:
-                      - id
-                      - name
-                      - nickname
-                      - family
-                      - token_limit
-                      - is_deprecated
-                      - stability
-                      - hosting
-                      - vision
-                      - reasoning
-                    title: CompletionModelPublic
-                    type: object
-                  FilePublic:
-                    properties:
-                      created_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Created At
-                      updated_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Updated At
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      name:
-                        title: Name
-                        type: string
-                      mimetype:
-                        title: Mimetype
-                        type: string
-                      size:
-                        title: Size
-                        type: integer
-                      transcription:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Transcription
-                    required:
-                      - id
-                      - name
-                      - mimetype
-                      - size
-                    title: FilePublic
-                    type: object
-                  InfoBlobAskAssistantPublic:
-                    properties:
-                      created_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Created At
-                      updated_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Updated At
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      metadata:
-                        "$ref": "#/components/schemas/InfoBlobMetadata"
-                      group_id:
-                        anyOf:
-                          - format: uuid
-                            type: string
-                          - type: 'null'
-                        title: Group Id
-                      website_id:
-                        anyOf:
-                          - format: uuid
-                            type: string
-                          - type: 'null'
-                        title: Website Id
-                      score:
-                        title: Score
-                        type: number
-                    required:
-                      - id
-                      - metadata
-                      - score
-                    title: InfoBlobAskAssistantPublic
-                    type: object
-                  InfoBlobMetadata:
-                    properties:
-                      url:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Url
-                      title:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Title
-                      embedding_model_id:
-                        format: uuid
-                        title: Embedding Model Id
-                        type: string
-                      size:
-                        title: Size
-                        type: integer
-                    required:
-                      - embedding_model_id
-                      - size
-                    title: InfoBlobMetadata
-                    type: object
-                  ModelFamily:
-                    enum:
-                      - openai
-                      - mistral
-                      - vllm
-                      - claude
-                      - azure
-                      - ovhcloud
-                      - e5
-                    title: ModelFamily
-                    type: string
-                  ModelHostingLocation:
-                    enum:
-                      - usa
-                      - eu
-                      - swe
-                    title: ModelHostingLocation
-                    type: string
-                  ModelOrg:
-                    enum:
-                      - OpenAI
-                      - Meta
-                      - Microsoft
-                      - Anthropic
-                      - Mistral
-                      - KBLab
-                      - Google
-                      - Berget
-                    title: ModelOrg
-                    type: string
-                  ModelStability:
-                    enum:
-                      - stable
-                      - experimental
-                    title: ModelStability
-                    type: string
-                  SecurityClassificationPublic:
-                    description: Basic security classification information.
-                    properties:
-                      created_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Created At
-                      updated_at:
-                        anyOf:
-                          - format: date-time
-                            type: string
-                          - type: 'null'
-                        title: Updated At
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      name:
-                        title: Name
-                        type: string
-                      description:
-                        anyOf:
-                          - type: string
-                          - type: 'null'
-                        title: Description
-                      security_level:
-                        title: Security Level
-                        type: integer
-                    required:
-                      - id
-                      - name
-                      - description
-                      - security_level
-                    title: SecurityClassificationPublic
-                    type: object
-                  ToolAssistant:
-                    properties:
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      handle:
-                        title: Handle
-                        type: string
-                    required:
-                      - id
-                      - handle
-                    title: ToolAssistant
-                    type: object
-                  UseTools:
-                    properties:
-                      assistants:
-                        items:
-                          "$ref": "#/components/schemas/ToolAssistant"
-                        title: Assistants
-                        type: array
-                    required:
-                      - assistants
-                    title: UseTools
-                    type: object
-                  WebSearchResultPublic:
-                    properties:
-                      id:
-                        format: uuid
-                        title: Id
-                        type: string
-                      title:
-                        title: Title
-                        type: string
-                      url:
-                        title: Url
-                        type: string
-                    required:
-                      - id
-                      - title
-                      - url
-                    title: WebSearchResultPublic
-                    type: object
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - assistants
       summary: Delete Assistant Session
-      operationId: delete_assistant_session_api_v1_assistants__id__sessions__session_id___delete
+      operationId: >-
+        delete_assistant_session_api_v1_assistants__id__sessions__session_id___delete
       parameters:
         - name: id
           in: path
@@ -2838,37 +2614,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SessionPublic"
+                $ref: '#/components/schemas/SessionPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/assistants/{id}/sessions/{session_id}/feedback/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/assistants/{id}/sessions/{session_id}/feedback/':
     post:
       tags:
         - assistants
       summary: Leave Feedback
-      operationId: leave_feedback_api_v1_assistants__id__sessions__session_id__feedback__post
+      operationId: >-
+        leave_feedback_api_v1_assistants__id__sessions__session_id__feedback__post
       parameters:
         - name: id
           in: path
@@ -2892,7 +2673,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SessionFeedback"
+              $ref: '#/components/schemas/SessionFeedback'
         required: true
       responses:
         '200':
@@ -2900,40 +2681,47 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SessionPublic"
+                $ref: '#/components/schemas/SessionPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/assistants/{id}/api-keys/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/assistants/{id}/api-keys/':
     get:
       tags:
         - assistants
       summary: Generate Read Only Assistant Key
-      description: |-
+      description: >-
         Generates a read-only api key for this assistant.
 
-        This api key can only be used on `POST /api/v1/assistants/{id}/sessions/`
+
+        This api key can only be used on `POST
+        /api/v1/assistants/{id}/sessions/`
+
         and `POST /api/v1/assistants/{id}/sessions/{session_id}/`.
       operationId: generate_read_only_assistant_key_api_v1_assistants__id__api_keys__get
       parameters:
@@ -2952,20 +2740,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/ApiKey"
+                $ref: '#/components/schemas/ApiKey'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/assistants/{id}/transfer/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/assistants/{id}/transfer/':
     post:
       tags:
         - assistants
@@ -2985,7 +2777,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/TransferApplicationRequest"
+              $ref: '#/components/schemas/TransferApplicationRequest'
         required: true
       responses:
         '204':
@@ -2995,14 +2787,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/assistants/{id}/publish/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/assistants/{id}/publish/':
     post:
       tags:
         - assistants
@@ -3032,32 +2828,104 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AssistantPublic"
+                $ref: '#/components/schemas/AssistantPublic'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/group-chats/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/assistants/{id}/token-estimate':
+    post:
+      tags:
+        - assistants
+      summary: Estimate token usage for text and files
+      description: >-
+        Estimate token usage for the given text and files for this assistant.
+
+
+        The Space Actor + FileService stack already enforces tenant and
+        ownership
+
+        boundaries; this endpoint adds lightweight guardrails to keep the
+        operation
+
+        responsive while supporting large-context models.
+      operationId: estimate_tokens_api_v1_assistants__id__token_estimate_post
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenEstimateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenEstimateResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/group-chats/{id}/':
     get:
       tags:
         - group-chats
@@ -3080,25 +2948,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GroupChatPublic"
+                $ref: '#/components/schemas/GroupChatPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - group-chats
@@ -3123,25 +2995,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     patch:
       tags:
         - group-chats
@@ -3162,7 +3038,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/GroupChatUpdateSchema"
+              $ref: '#/components/schemas/GroupChatUpdateSchema'
         required: true
       responses:
         '200':
@@ -3170,38 +3046,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GroupChatPublic"
+                $ref: '#/components/schemas/GroupChatPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/group-chats/{id}/publish/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/group-chats/{id}/publish/':
     post:
       tags:
         - group-chats
@@ -3231,40 +3111,47 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GroupChatPublic"
+                $ref: '#/components/schemas/GroupChatPublic'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/conversations/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /conversations/:
     get:
       tags:
         - conversations
       summary: List Conversations
-      description: |-
+      description: >-
         Gets conversations (sessions) for an assistant or group chat.
 
-        Provide either assistant_id or group_chat_id (but not both) to filter sessions.
+
+        Provide either assistant_id or group_chat_id (but not both) to filter
+        sessions.
+
         If neither is provided, an error will be returned.
       operationId: list_conversations_api_v1_conversations__get
       parameters:
@@ -3327,60 +3214,88 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/CursorPaginatedResponse_SessionMetadataPublic_"
+                $ref: >-
+                  #/components/schemas/CursorPaginatedResponse_SessionMetadataPublic_
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - conversations
       summary: Chat
-      description: |-
+      description: >-
         Unified endpoint for communicating with an assistant or a group chat.
 
-        If request.session_id is provided: continues an existing conversation.
-        Otherwise: starts a new conversation with the specified assistant or group chat.
 
-        Either request.session_id, request.assistant_id, or request.group_chat_id must be provided.
+        If request.session_id is provided: continues an existing conversation.
+
+        Otherwise: starts a new conversation with the specified assistant or
+        group chat.
+
+
+        Either request.session_id, request.assistant_id, or
+        request.group_chat_id must be provided.
+
 
         For group chats:
+
         - Specify the group_chat_id to chat with a group chat
-        - If tools.assistants contains an assistant, that specific assistant will be targeted
+
+        - If tools.assistants contains an assistant, that specific assistant
+        will be targeted
           (requires the group chat to have allow_mentions=True).
-        - If no assistant is targeted, the most appropriate assistant will be selected.
-        - When multiple assistants could answer a question, the system will choose the most relevant one
+        - If no assistant is targeted, the most appropriate assistant will be
+        selected.
+
+        - When multiple assistants could answer a question, the system will
+        choose the most relevant one
           or select the first matching assistant if relevance scores are similar.
 
         For regular assistants:
-        - The tools.assistants field can be used for directing the request to a tool assistant.
+
+        - The tools.assistants field can be used for directing the request to a
+        tool assistant.
+
 
         Streams the response as Server-Sent Events if stream == true.
+
         The following SSE response models are supported in the stream:
+
         - SSEText: Text completion chunks
+
         - SSEIntricEvent: Internal events like generating an image
+
         - SSEFiles: Generated files/images responses
+
         - SSEFirstChunk: Initial response with metadata
+
+        - SSEError: Error events (API errors, authentication failures, rate
+        limits, etc.)
       operationId: chat_api_v1_conversations__post
       parameters:
         - name: version
@@ -3398,7 +3313,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/ConversationRequest"
+              $ref: '#/components/schemas/ConversationRequest'
         required: true
       responses:
         '200':
@@ -3421,79 +3336,13 @@ paths:
                       references:
                         type: array
                         items:
-                          "$ref": "#/components/schemas/InfoBlobAskAssistantPublic"
+                          $ref: '#/components/schemas/InfoBlobAskAssistantPublic'
                         title: References
                     required:
                       - answer
                       - references
                       - session_id
                     title: SSEText
-                    "$defs":
-                      InfoBlobAskAssistantPublic:
-                        properties:
-                          created_at:
-                            anyOf:
-                              - format: date-time
-                                type: string
-                              - type: 'null'
-                            title: Created At
-                          updated_at:
-                            anyOf:
-                              - format: date-time
-                                type: string
-                              - type: 'null'
-                            title: Updated At
-                          id:
-                            format: uuid
-                            title: Id
-                            type: string
-                          metadata:
-                            "$ref": "#/components/schemas/InfoBlobMetadata"
-                          group_id:
-                            anyOf:
-                              - format: uuid
-                                type: string
-                              - type: 'null'
-                            title: Group Id
-                          website_id:
-                            anyOf:
-                              - format: uuid
-                                type: string
-                              - type: 'null'
-                            title: Website Id
-                          score:
-                            title: Score
-                            type: number
-                        required:
-                          - id
-                          - metadata
-                          - score
-                        title: InfoBlobAskAssistantPublic
-                        type: object
-                      InfoBlobMetadata:
-                        properties:
-                          url:
-                            anyOf:
-                              - type: string
-                              - type: 'null'
-                            title: Url
-                          title:
-                            anyOf:
-                              - type: string
-                              - type: 'null'
-                            title: Title
-                          embedding_model_id:
-                            format: uuid
-                            title: Embedding Model Id
-                            type: string
-                          size:
-                            title: Size
-                            type: integer
-                        required:
-                          - embedding_model_id
-                          - size
-                        title: InfoBlobMetadata
-                        type: object
                   - type: object
                     properties:
                       session_id:
@@ -3501,17 +3350,11 @@ paths:
                         format: uuid
                         title: Session Id
                       intric_event_type:
-                        "$ref": "#/components/schemas/IntricEventType"
+                        $ref: '#/components/schemas/IntricEventType'
                     required:
                       - intric_event_type
                       - session_id
                     title: SSEIntricEvent
-                    "$defs":
-                      IntricEventType:
-                        enum:
-                          - generating_image
-                        title: IntricEventType
-                        type: string
                   - type: object
                     properties:
                       session_id:
@@ -3521,52 +3364,12 @@ paths:
                       generated_files:
                         type: array
                         items:
-                          "$ref": "#/components/schemas/FilePublic"
+                          $ref: '#/components/schemas/FilePublic'
                         title: Generated Files
                     required:
                       - generated_files
                       - session_id
                     title: SSEFiles
-                    "$defs":
-                      FilePublic:
-                        properties:
-                          created_at:
-                            anyOf:
-                              - format: date-time
-                                type: string
-                              - type: 'null'
-                            title: Created At
-                          updated_at:
-                            anyOf:
-                              - format: date-time
-                                type: string
-                              - type: 'null'
-                            title: Updated At
-                          id:
-                            format: uuid
-                            title: Id
-                            type: string
-                          name:
-                            title: Name
-                            type: string
-                          mimetype:
-                            title: Mimetype
-                            type: string
-                          size:
-                            title: Size
-                            type: integer
-                          transcription:
-                            anyOf:
-                              - type: string
-                              - type: 'null'
-                            title: Transcription
-                        required:
-                          - id
-                          - name
-                          - mimetype
-                          - size
-                        title: FilePublic
-                        type: object
                   - type: object
                     properties:
                       session_id:
@@ -3582,24 +3385,24 @@ paths:
                       files:
                         type: array
                         items:
-                          "$ref": "#/components/schemas/FilePublic"
+                          $ref: '#/components/schemas/FilePublic'
                         title: Files
                       generated_files:
                         type: array
                         items:
-                          "$ref": "#/components/schemas/FilePublic"
+                          $ref: '#/components/schemas/FilePublic'
                         title: Generated Files
                       references:
                         type: array
                         items:
-                          "$ref": "#/components/schemas/InfoBlobAskAssistantPublic"
+                          $ref: '#/components/schemas/InfoBlobAskAssistantPublic'
                         title: References
                       tools:
-                        "$ref": "#/components/schemas/UseTools"
+                        $ref: '#/components/schemas/UseTools'
                       web_search_references:
                         type: array
                         items:
-                          "$ref": "#/components/schemas/WebSearchResultPublic"
+                          $ref: '#/components/schemas/WebSearchResultPublic'
                         title: Web Search References
                     required:
                       - answer
@@ -3611,179 +3414,53 @@ paths:
                       - tools
                       - web_search_references
                     title: SSEFirstChunk
-                    "$defs":
-                      FilePublic:
-                        properties:
-                          created_at:
-                            anyOf:
-                              - format: date-time
-                                type: string
-                              - type: 'null'
-                            title: Created At
-                          updated_at:
-                            anyOf:
-                              - format: date-time
-                                type: string
-                              - type: 'null'
-                            title: Updated At
-                          id:
-                            format: uuid
-                            title: Id
-                            type: string
-                          name:
-                            title: Name
-                            type: string
-                          mimetype:
-                            title: Mimetype
-                            type: string
-                          size:
-                            title: Size
-                            type: integer
-                          transcription:
-                            anyOf:
-                              - type: string
-                              - type: 'null'
-                            title: Transcription
-                        required:
-                          - id
-                          - name
-                          - mimetype
-                          - size
-                        title: FilePublic
-                        type: object
-                      InfoBlobAskAssistantPublic:
-                        properties:
-                          created_at:
-                            anyOf:
-                              - format: date-time
-                                type: string
-                              - type: 'null'
-                            title: Created At
-                          updated_at:
-                            anyOf:
-                              - format: date-time
-                                type: string
-                              - type: 'null'
-                            title: Updated At
-                          id:
-                            format: uuid
-                            title: Id
-                            type: string
-                          metadata:
-                            "$ref": "#/components/schemas/InfoBlobMetadata"
-                          group_id:
-                            anyOf:
-                              - format: uuid
-                                type: string
-                              - type: 'null'
-                            title: Group Id
-                          website_id:
-                            anyOf:
-                              - format: uuid
-                                type: string
-                              - type: 'null'
-                            title: Website Id
-                          score:
-                            title: Score
-                            type: number
-                        required:
-                          - id
-                          - metadata
-                          - score
-                        title: InfoBlobAskAssistantPublic
-                        type: object
-                      InfoBlobMetadata:
-                        properties:
-                          url:
-                            anyOf:
-                              - type: string
-                              - type: 'null'
-                            title: Url
-                          title:
-                            anyOf:
-                              - type: string
-                              - type: 'null'
-                            title: Title
-                          embedding_model_id:
-                            format: uuid
-                            title: Embedding Model Id
-                            type: string
-                          size:
-                            title: Size
-                            type: integer
-                        required:
-                          - embedding_model_id
-                          - size
-                        title: InfoBlobMetadata
-                        type: object
-                      ToolAssistant:
-                        properties:
-                          id:
-                            format: uuid
-                            title: Id
-                            type: string
-                          handle:
-                            title: Handle
-                            type: string
-                        required:
-                          - id
-                          - handle
-                        title: ToolAssistant
-                        type: object
-                      UseTools:
-                        properties:
-                          assistants:
-                            items:
-                              "$ref": "#/components/schemas/ToolAssistant"
-                            title: Assistants
-                            type: array
-                        required:
-                          - assistants
-                        title: UseTools
-                        type: object
-                      WebSearchResultPublic:
-                        properties:
-                          id:
-                            format: uuid
-                            title: Id
-                            type: string
-                          title:
-                            title: Title
-                            type: string
-                          url:
-                            title: Url
-                            type: string
-                        required:
-                          - id
-                          - title
-                          - url
-                        title: WebSearchResultPublic
-                        type: object
+                  - type: object
+                    properties:
+                      session_id:
+                        type: string
+                        format: uuid
+                        title: Session Id
+                      error:
+                        type: string
+                        title: Error
+                      error_code:
+                        anyOf:
+                          - type: integer
+                          - type: 'null'
+                        title: Error Code
+                    required:
+                      - error
+                      - session_id
+                    title: SSEError
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/conversations/{session_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/conversations/{session_id}/':
     get:
       tags:
         - conversations
@@ -3808,31 +3485,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SessionPublic"
+                $ref: '#/components/schemas/SessionPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - conversations
@@ -3859,26 +3540,30 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/conversations/{session_id}/feedback/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/conversations/{session_id}/feedback/':
     post:
       tags:
         - conversations
@@ -3901,7 +3586,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SessionFeedback"
+              $ref: '#/components/schemas/SessionFeedback'
         required: true
       responses:
         '200':
@@ -3909,32 +3594,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SessionPublic"
+                $ref: '#/components/schemas/SessionPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/conversations/{session_id}/title/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/conversations/{session_id}/title/':
     post:
       tags:
         - conversations
@@ -3957,32 +3646,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SessionPublic"
+                $ref: '#/components/schemas/SessionPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/services/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /services/:
     get:
       tags:
         - services
@@ -4003,29 +3696,37 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_ServicePublicWithUser_"
+                $ref: '#/components/schemas/PaginatedResponse_ServicePublicWithUser_'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - services
       summary: Create Service
-      description: |-
+      description: >-
         Create a service.
+
 
         `json_schema` is required if `output_validation` is 'json'.
 
-        Conversely, `json_schema` is not evaluated if `output_format` is not 'json'.
+
+        Conversely, `json_schema` is not evaluated if `output_format` is not
+        'json'.
+
 
         if `output_format` is omitted, the output will not be formatted.
       operationId: create_service_api_v1_services__post
@@ -4033,7 +3734,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/ServiceCreatePublic"
+              $ref: '#/components/schemas/ServiceCreatePublic'
         required: true
       responses:
         '200':
@@ -4041,25 +3742,25 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/ServicePublicWithUser"
+                $ref: '#/components/schemas/ServicePublicWithUser'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       deprecated: true
       security:
         - OAuth2PasswordBearer: []
@@ -4067,7 +3768,11 @@ paths:
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/services/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/services/{id}/':
     get:
       tags:
         - services
@@ -4089,25 +3794,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/ServicePublicWithUser"
+                $ref: '#/components/schemas/ServicePublicWithUser'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - services
@@ -4128,7 +3837,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/PartialServiceUpdatePublic"
+              $ref: '#/components/schemas/PartialServiceUpdatePublic'
         required: true
       responses:
         '200':
@@ -4136,25 +3845,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/ServicePublicWithUser"
+                $ref: '#/components/schemas/ServicePublicWithUser'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - services
@@ -4178,26 +3891,30 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/services/{id}/run/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/services/{id}/run/':
     get:
       tags:
         - services
@@ -4219,31 +3936,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_ServiceRun_"
+                $ref: '#/components/schemas/PaginatedResponse_ServiceRun_'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - services
       summary: Run Service
-      description: The schema of the output will be depending on the output validation
-        of the service
+      description: >-
+        The schema of the output will be depending on the output validation of
+        the service
       operationId: run_service_api_v1_services__id__run__post
       parameters:
         - name: id
@@ -4259,7 +3981,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/RunService"
+              $ref: '#/components/schemas/RunService'
         required: true
       responses:
         '200':
@@ -4267,32 +3989,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/ServiceOutput"
+                $ref: '#/components/schemas/ServiceOutput'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/services/{id}/transfer/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/services/{id}/transfer/':
     post:
       tags:
         - services
@@ -4312,7 +4038,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/TransferApplicationRequest"
+              $ref: '#/components/schemas/TransferApplicationRequest'
         required: true
       responses:
         '204':
@@ -4322,14 +4048,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/logging/{message_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/logging/{message_id}/':
     get:
       tags:
         - logging
@@ -4351,20 +4081,23 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/MessageLogging"
+                $ref: '#/components/schemas/MessageLogging'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
-        - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/analysis/counts/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /analysis/counts/:
     get:
       tags:
         - analysis
@@ -4377,23 +4110,30 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Counts"
+                $ref: '#/components/schemas/Counts'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/analysis/metadata-statistics/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /analysis/metadata-statistics/:
     get:
       tags:
         - analysis
       summary: Get Metadata
-      description: |-
+      description: >-
         Data for analytics.
 
+
         Note on datetime parameters:
-        - If no time is provided in the datetime, time components default to 00:00:00
+
+        - If no time is provided in the datetime, time components default to
+        00:00:00
       operationId: get_metadata_api_v1_analysis_metadata_statistics__get
       parameters:
         - name: start_date
@@ -4404,7 +4144,7 @@ paths:
           schema:
             type: string
             format: date-time
-            default: '2025-08-17T11:06:40.857037Z'
+            default: '2026-01-13T08:15:34.279393Z'
             title: Start Date
         - name: end_date
           in: query
@@ -4414,7 +4154,7 @@ paths:
           schema:
             type: string
             format: date-time
-            default: '2025-09-16T12:07:40.857045Z'
+            default: '2026-02-12T09:16:34.279400Z'
             title: End Date
       responses:
         '200':
@@ -4422,28 +4162,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/MetadataStatistics"
+                $ref: '#/components/schemas/MetadataStatistics'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/analysis/assistants/{assistant_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/analysis/assistants/{assistant_id}/':
     get:
       tags:
         - analysis
       summary: Get Most Recent Questions
-      description: |-
-        Get all the questions asked to an assistant in the last `days_since` days.
+      description: >-
+        Get all the questions asked to an assistant in the last `days_since`
+        days.
+
 
         `days_since`: How long back in time to get the questions.
+
 
         `from_date`: Start date for filtering questions.
             If no time is provided, time components default to 00:00:00.
@@ -4451,7 +4198,8 @@ paths:
         `to_date`: End date for filtering questions.
             If no time is provided, time components default to 00:00:00.
 
-        `include_followups`: If not selected, only the first question of a session is returned.
+        `include_followups`: If not selected, only the first question of a
+        session is returned.
             Order is by date ascending, but if followups are included they are grouped together
             with their original question.
       operationId: get_most_recent_questions_api_v1_analysis_assistants__assistant_id___get
@@ -4513,28 +4261,33 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_Message_"
+                $ref: '#/components/schemas/PaginatedResponse_Message_'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - analysis
       summary: Ask Question About Questions
-      description: |-
+      description: >-
         Ask a question with the questions asked to an assistant in the last
           `days_since` days as the context.
 
         `days_since`: How long back in time to get the questions.
+
 
         `from_date`: Start date for filtering questions.
             If no time is provided, time components default to 00:00:00.
@@ -4542,10 +4295,12 @@ paths:
         `to_date`: End date for filtering questions.
             If no time is provided, time components default to 00:00:00.
 
-        `include_followups`: If not selected, only the first question of a session is returned.
+        `include_followups`: If not selected, only the first question of a
+        session is returned.
             Order is by date ascending, but if followups are included they are grouped together
             with their original question.
-      operationId: ask_question_about_questions_api_v1_analysis_assistants__assistant_id___post
+      operationId: >-
+        ask_question_about_questions_api_v1_analysis_assistants__assistant_id___post
       parameters:
         - name: assistant_id
           in: path
@@ -4602,7 +4357,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/AskAnalysis"
+              $ref: '#/components/schemas/AskAnalysis'
         required: true
       responses:
         '200':
@@ -4615,23 +4370,32 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/analysis/conversation-insights/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /analysis/conversation-insights/:
     get:
       tags:
         - analysis
       summary: Get Conversation Insights
-      description: |-
-        Get statistics about conversations for either an assistant or a group chat.
+      description: >-
+        Get statistics about conversations for either an assistant or a group
+        chat.
+
 
         Either assistant_id or group_chat_id must be provided, but not both.
-        Start time and end time are optional filters. If no time is provided in the datetime parameters,
+
+        Start time and end time are optional filters. If no time is provided in
+        the datetime parameters,
+
         time components default to 00:00:00.
       operationId: get_conversation_insights_api_v1_analysis_conversation_insights__get
       parameters:
@@ -4685,22 +4449,27 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/ConversationInsightResponse"
+                $ref: '#/components/schemas/ConversationInsightResponse'
         '403':
-          description: Forbidden - Either user is not ADMIN/EDITOR or insights are
-            not enabled
+          description: >-
+            Forbidden - Either user is not ADMIN/EDITOR or insights are not
+            enabled
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - analysis
@@ -4724,7 +4493,8 @@ paths:
 
         Returns:
             AnalysisAnswer containing the AI response
-      operationId: ask_unified_questions_about_questions_api_v1_analysis_conversation_insights__post
+      operationId: >-
+        ask_unified_questions_about_questions_api_v1_analysis_conversation_insights__post
       parameters:
         - name: days_since
           in: query
@@ -4794,7 +4564,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/AskAnalysis"
+              $ref: '#/components/schemas/AskAnalysis'
         required: true
       responses:
         '200':
@@ -4807,14 +4577,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/analysis/conversation-insights/sessions/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /analysis/conversation-insights/sessions/:
     get:
       tags:
         - analysis
@@ -4840,7 +4614,8 @@ paths:
 
         Returns:
             Paginated list of sessions
-      operationId: get_conversation_insight_sessions_api_v1_analysis_conversation_insights_sessions__get
+      operationId: >-
+        get_conversation_insight_sessions_api_v1_analysis_conversation_insights_sessions__get
       parameters:
         - name: assistant_id
           in: query
@@ -4934,32 +4709,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/CursorPaginatedResponse_SessionMetadataPublic_"
+                $ref: >-
+                  #/components/schemas/CursorPaginatedResponse_SessionMetadataPublic_
         '403':
-          description: Forbidden - Either user is not ADMIN/EDITOR or insights are
-            not enabled
+          description: >-
+            Forbidden - Either user is not ADMIN/EDITOR or insights are not
+            enabled
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/analysis/conversation-insights/sessions/{session_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/analysis/conversation-insights/sessions/{session_id}/':
     get:
       tags:
         - analysis
       summary: Get Conversation Insight Session
-      description: |-
+      description: >-
         Get a specific session with insight access.
 
-        This endpoint requires the user to be OWNER or EDITOR, and the assistant/group chat
+
+        This endpoint requires the user to be OWNER or EDITOR, and the
+        assistant/group chat
+
         must have insight_enabled set to true.
+
 
         Args:
             session_id: UUID of the session
@@ -4968,7 +4753,8 @@ paths:
 
         Returns:
             Session data
-      operationId: get_conversation_insight_session_api_v1_analysis_conversation_insights_sessions__session_id___get
+      operationId: >-
+        get_conversation_insight_session_api_v1_analysis_conversation_insights_sessions__session_id___get
       parameters:
         - name: session_id
           in: path
@@ -4985,23 +4771,2070 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SessionPublic"
+                $ref: '#/components/schemas/SessionPublic'
         '403':
-          description: Forbidden - Either user is not ADMIN/EDITOR or insights are
-            not enabled
+          description: >-
+            Forbidden - Either user is not ADMIN/EDITOR or insights are not
+            enabled
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/jobs/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/users/:
+    get:
+      tags:
+        - admin
+      summary: List users with pagination and search
+      description: >-
+        List tenant users with pagination, fuzzy search, and sorting
+        capabilities.
+
+
+        **Performance Optimization:**
+
+        - Uses pg_trgm GIN indexes for efficient fuzzy text search (email and
+        username)
+
+        - Uses composite B-tree indexes for fast tenant-scoped sorting
+
+        - Sub-second response time even with 10,000+ users per tenant
+
+
+        **Pagination:**
+
+        - Max depth: 100 pages (prevents deep pagination performance issues)
+
+        - Default: 100 users per page, sorted by creation date (newest first)
+
+        - Supports custom page sizes (1-100)
+
+
+        **Search:**
+
+        - Email search: Case-insensitive partial match (e.g., "john" matches
+        john.doe@example.com)
+
+        - Name search: Case-insensitive partial match on username (e.g., "emma"
+        matches emma.andersson)
+
+        - Combined search: Use both filters with AND logic
+
+
+        **Sorting:**
+
+        - Sort by: email, username, or created_at (default)
+
+        - Sort order: asc or desc (default)
+
+
+        **Example Requests:**
+
+
+        Default (first 100 users, newest first):
+
+        ```
+
+        GET /api/v1/admin/users/
+
+        ```
+
+
+        Custom page size (50 users per page):
+
+        ```
+
+        GET /api/v1/admin/users/?page_size=50
+
+        ```
+
+
+        Email search (find users at municipality domain):
+
+        ```
+
+        GET /api/v1/admin/users/?search_email=@municipality.se
+
+        ```
+
+
+        Name search (find users named Emma):
+
+        ```
+
+        GET /api/v1/admin/users/?search_name=emma
+
+        ```
+
+
+        Combined search and pagination:
+
+        ```
+
+        GET
+        /api/v1/admin/users/?search_email=@municipality.se&page=2&page_size=50
+
+        ```
+
+
+        Sort by email ascending:
+
+        ```
+
+        GET /api/v1/admin/users/?sort_by=email&sort_order=asc
+
+        ```
+
+
+        **Response Format:**
+
+        ```json
+
+        {
+          "items": [...],
+          "metadata": {
+            "page": 1,
+            "page_size": 100,
+            "total_count": 543,
+            "total_pages": 6,
+            "has_next": true,
+            "has_previous": false
+          }
+        }
+
+        ```
+
+
+        **Important Notes:**
+
+        - Only active users (not soft-deleted) are returned
+
+        - All results are isolated to your tenant (cross-tenant access is
+        prevented)
+
+        - Max depth limit (100 pages) ensures consistent performance
+      operationId: get_users_api_v1_admin_users__get
+      parameters:
+        - name: page
+          in: query
+          description: Page number (1-100)
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 1
+            description: Page number (1-100)
+            maximum: 100
+            minimum: 1
+            title: Page
+        - name: page_size
+          in: query
+          description: Users per page (1-100)
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 100
+            description: Users per page (1-100)
+            maximum: 100
+            minimum: 1
+            title: Page Size
+        - name: search_email
+          in: query
+          description: 'Search by email (case-insensitive, partial match)'
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: 'Search by email (case-insensitive, partial match)'
+            title: Search Email
+        - name: search_name
+          in: query
+          description: 'Search by username (case-insensitive, partial match)'
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: 'Search by username (case-insensitive, partial match)'
+            title: Search Name
+        - name: sort_by
+          in: query
+          description: 'Sort field (default: alphabetical by email)'
+          required: false
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/SortField'
+            default: email
+            description: 'Sort field (default: alphabetical by email)'
+        - name: sort_order
+          in: query
+          description: 'Sort order (default: ascending A-Z)'
+          required: false
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/SortOrder'
+            default: asc
+            description: 'Sort order (default: ascending A-Z)'
+        - name: state_filter
+          in: query
+          description: >-
+            Filter by user state (active includes invited, inactive for
+            temporary leave)
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/StateFilter'
+              - type: 'null'
+            description: >-
+              Filter by user state (active includes invited, inactive for
+              temporary leave)
+            title: State Filter
+      responses:
+        '200':
+          description: Paginated list of users successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedUsersResponse_UserAdminView_'
+              example:
+                items:
+                  - id: 123e4567-e89b-12d3-a456-426614174000
+                    username: emma.andersson
+                    email: emma.andersson@municipality.se
+                    state: active
+                    used_tokens: 1250
+                    is_active: true
+                    email_verified: true
+                    quota_limit: 50000000
+                    quota_used: 12500000
+                    created_at: '2025-09-01T08:30:00Z'
+                    updated_at: '2025-10-15T14:20:00Z'
+                    roles: []
+                    predefined_roles: []
+                    user_groups: []
+                metadata:
+                  page: 1
+                  page_size: 100
+                  total_count: 543
+                  total_pages: 6
+                  has_next: true
+                  has_previous: false
+        '400':
+          description: Invalid pagination parameters (page/page_size out of bounds)
+          content:
+            application/json:
+              example:
+                type: 'about:blank'
+                title: Bad Request
+                status: 400
+                detail: page must not exceed 100 (max depth limit)
+                instance: /api/v1/admin/users/
+        '401':
+          description: Authentication required (invalid or missing API key)
+        '403':
+          description: Admin permissions required
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    post:
+      tags:
+        - admin
+      summary: Create new user in tenant
+      description: >-
+        Creates a new user account within your tenant. The user will be created
+        with the provided credentials and automatically associated with your
+        organization. Returns user details including a new API key for the user.
+      operationId: register_user_api_v1_admin_users__post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserAddAdmin'
+        required: true
+      responses:
+        '201':
+          description: User successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCreatedAdminView'
+        '400':
+          description: Invalid input data or validation errors
+        '401':
+          description: Authentication required (invalid or missing API key)
+        '403':
+          description: Admin permissions required
+        '409':
+          description: Username or email already exists in your tenant
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/users/{username}/':
+    get:
+      tags:
+        - admin
+      summary: Get user details
+      description: >-
+        Retrieves a single user's complete details using their username. User
+        must exist in your tenant and not be soft-deleted. Returns the same
+        detailed information format as other admin endpoints.
+      operationId: get_user_api_v1_admin_users__username___get
+      parameters:
+        - name: username
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            title: Username
+      responses:
+        '200':
+          description: User details successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAdminView'
+        '400':
+          description: Cross-tenant access attempt
+        '401':
+          description: Authentication required (invalid or missing API key)
+        '403':
+          description: Admin permissions required
+        '404':
+          description: User not found in your tenant (may be soft-deleted)
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    post:
+      tags:
+        - admin
+      summary: Update existing user
+      description: >-
+        Updates an existing user's details using their username. Only fields
+        provided in the request body will be updated. User must exist in your
+        tenant and not be soft-deleted.
+      operationId: update_user_api_v1_admin_users__username___post
+      parameters:
+        - name: username
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            title: Username
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserUpdatePublic'
+        required: true
+      responses:
+        '200':
+          description: User successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAdminView'
+        '400':
+          description: >-
+            Invalid input data, validation errors, or cross-tenant access
+            attempt
+        '401':
+          description: Authentication required (invalid or missing API key)
+        '403':
+          description: Admin permissions required
+        '404':
+          description: User not found in your tenant (may be soft-deleted)
+        '409':
+          description: Email already exists in your tenant
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/users/{username}':
+    delete:
+      tags:
+        - admin
+      summary: Soft delete user
+      description: >-
+        Soft deletes a user by setting deleted_at timestamp and
+        UserState.DELETED. The user's record is preserved for audit purposes but
+        they can no longer authenticate. This operation is irreversible through
+        the API.
+      operationId: delete_user_api_v1_admin_users__username__delete
+      parameters:
+        - name: username
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            title: Username
+      responses:
+        '200':
+          description: User successfully soft deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteResponse'
+        '400':
+          description: Cannot delete yourself or cross-tenant access attempt
+        '401':
+          description: Authentication required (invalid or missing API key)
+        '403':
+          description: Admin permissions required
+        '404':
+          description: User not found in your tenant (may already be soft-deleted)
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/users/{username}/deactivate':
+    post:
+      tags:
+        - admin
+      summary: Deactivate user (temporary leave)
+      description: >-
+        Sets user state to INACTIVE for temporary unavailability such as sick
+        leave, vacation, or parental leave. User cannot login but account data
+        is fully preserved. This is reversible through reactivation.
+      operationId: deactivate_user_api_v1_admin_users__username__deactivate_post
+      parameters:
+        - name: username
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            title: Username
+      responses:
+        '200':
+          description: User successfully deactivated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAdminView'
+        '400':
+          description: Cannot deactivate yourself or cross-tenant access attempt
+        '401':
+          description: Authentication required (invalid or missing API key)
+        '403':
+          description: Admin permissions required
+        '404':
+          description: User not found in your tenant
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/users/{username}/reactivate':
+    post:
+      tags:
+        - admin
+      summary: Reactivate user (return to active)
+      description: >-
+        Sets user state to ACTIVE from any previous state (INACTIVE or DELETED).
+        Restores full system access and clears deletion timestamps if present.
+        Use for employees returning from leave or rare rehire cases.
+      operationId: reactivate_user_api_v1_admin_users__username__reactivate_post
+      parameters:
+        - name: username
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            title: Username
+      responses:
+        '200':
+          description: User successfully reactivated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAdminView'
+        '400':
+          description: Cross-tenant access attempt
+        '401':
+          description: Authentication required (invalid or missing API key)
+        '403':
+          description: Admin permissions required
+        '404':
+          description: User not found in your tenant
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/users/inactive:
+    get:
+      tags:
+        - admin
+      summary: List inactive users
+      description: >-
+        Returns all users in INACTIVE state within your tenant. These are
+        employees on temporary leave who cannot login but are still employed.
+        Use for tracking who is temporarily unavailable.
+      operationId: get_inactive_users_api_v1_admin_users_inactive_get
+      responses:
+        '200':
+          description: List of inactive users successfully retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserStateListItem'
+                title: Response Get Inactive Users Api V1 Admin Users Inactive Get
+        '401':
+          description: Authentication required (invalid or missing API key)
+        '403':
+          description: Admin permissions required
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/users/deleted:
+    get:
+      tags:
+        - admin
+      summary: List deleted users
+      description: >-
+        Returns all users in DELETED state within your tenant. These are
+        employees who have left the organization and cannot login. Records are
+        preserved for audit purposes and potential cleanup by external systems.
+      operationId: get_deleted_users_api_v1_admin_users_deleted_get
+      responses:
+        '200':
+          description: List of deleted users successfully retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserDeletedListItem'
+                title: Response Get Deleted Users Api V1 Admin Users Deleted Get
+        '401':
+          description: Authentication required (invalid or missing API key)
+        '403':
+          description: Admin permissions required
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/predefined-roles/:
+    get:
+      tags:
+        - admin
+      summary: Get predefined roles for tenant
+      description: >-
+        Retrieves all predefined roles available for the authenticated tenant.
+        Requires tenant admin (owner) permissions. Returns the same structure as
+        the sysadmin endpoint for consistency.
+      operationId: get_predefined_roles_api_v1_admin_predefined_roles__get
+      responses:
+        '200':
+          description: List of predefined roles successfully retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PredefinedRoleInDB'
+                title: >-
+                  Response Get Predefined Roles Api V1 Admin Predefined Roles 
+                  Get
+              example:
+                - id: 550e8400-e29b-41d4-a716-446655440001
+                  name: Owner
+                  permissions:
+                    - admin
+                    - AI
+                    - assistants
+                    - group_chats
+                  created_at: '2024-01-15T10:30:00Z'
+                  updated_at: '2024-01-15T10:30:00Z'
+                - id: 550e8400-e29b-41d4-a716-446655440002
+                  name: AI Configurator
+                  permissions:
+                    - AI
+                    - assistants
+                  created_at: '2024-01-15T10:30:00Z'
+                  updated_at: '2024-01-15T10:30:00Z'
+        '401':
+          description: Authentication required (invalid or missing API key)
+        '403':
+          description: Admin permissions required (owner role)
+        '500':
+          description: Internal server error while fetching predefined roles
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/privacy-policy/:
+    post:
+      tags:
+        - admin
+      summary: Update Privacy Policy
+      operationId: update_privacy_policy_api_v1_admin_privacy_policy__post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PrivacyPolicy'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantPublic'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/credentials/{provider}':
+    put:
+      tags:
+        - admin
+      summary: Set API credential for current tenant
+      description: >-
+        Set or update API credentials for a specific LLM provider. Tenant admin
+        only. Provider-specific fields are validated.
+      operationId: set_credential_api_v1_admin_credentials__provider__put
+      parameters:
+        - name: provider
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            enum:
+              - openai
+              - anthropic
+              - azure
+              - berget
+              - gdm
+              - mistral
+              - ovhcloud
+              - gemini
+              - cohere
+            title: Provider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: >-
+                #/components/schemas/intric__tenants__presentation__tenant_self_credentials_router__SetCredentialRequest
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: >-
+                  #/components/schemas/intric__tenants__presentation__tenant_self_credentials_router__SetCredentialResponse
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/credentials/:
+    get:
+      tags:
+        - admin
+      summary: List API credentials for current tenant
+      description: >-
+        List all configured API credentials with masked keys and encryption
+        status. Tenant admin only.
+      operationId: list_credentials_api_v1_admin_credentials__get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: >-
+                  #/components/schemas/intric__tenants__presentation__tenant_self_credentials_router__ListCredentialsResponse
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/templates/assistants/:
+    get:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: List tenant's assistant templates
+      description: |-
+        List all active (non-deleted) assistant templates owned by your tenant.
+
+        **Admin Only:** Requires admin permissions.
+
+        **Visibility:**
+        - Only shows templates where `tenant_id` matches your tenant
+        - Excludes global templates (tenant_id = NULL)
+        - Excludes soft-deleted templates (deleted_at IS NOT NULL)
+
+        Use this endpoint for the admin template management page.
+      operationId: list_templates_api_v1_admin_templates_assistants__get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantTemplateAdminListPublic'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    post:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Create assistant template
+      description: |-
+        Create a new assistant template for your tenant.
+
+        **Admin Only:** Requires admin permissions.
+
+        **Prerequisites:**
+        - Feature flag `using_templates` must be enabled for your tenant
+        - Template name must be unique within your tenant
+
+        **Business Logic:**
+        - Template is automatically scoped to your tenant
+        - Original state is saved in `original_snapshot` for rollback
+        - Template immediately available in gallery for users in your tenant
+
+        **Example Request:**
+        ```json
+        {
+          "name": "Customer Support Assistant",
+          "description": "Handles customer inquiries professionally and efficiently",
+          "category": "Support",
+          "prompt": "You are a helpful customer support agent. Always be polite and professional.",
+          "completion_model_kwargs": {"temperature": 0.7, "max_tokens": 500},
+          "wizard": {
+            "attachments": {"required": false, "title": "Add product docs", "description": "Optional documentation"},
+            "collections": {"required": true, "title": "Select knowledge base", "description": "Choose support knowledge base"}
+          }
+        }
+        ```
+      operationId: create_template_api_v1_admin_templates_assistants__post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssistantTemplateAdminCreate'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantTemplateAdminPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '424':
+          description: Failed Dependency
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/templates/assistants/{template_id}':
+    delete:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Delete assistant template
+      description: |-
+        Soft-delete an assistant template (marks with deleted_at timestamp).
+
+        **Admin Only:** Requires admin permissions.
+
+        **Safety Checks:**
+        - Validates template belongs to your tenant
+        - Checks if template is currently in use by assistants
+        - Returns 409 Conflict if template is in use with usage count
+
+        **Behavior:**
+        - Sets `deleted_at` to current timestamp
+        - Template no longer appears in gallery or admin list
+        - Template can be viewed in deleted list (audit trail)
+        - Template remains in database (soft-delete only)
+
+        **Error Response (In Use):**
+        ```json
+        {
+          "detail": "Cannot delete template 'My Template'. It is used by 3 assistant(s).",
+          "error_code": "BAD_REQUEST"
+        }
+        ```
+      operationId: delete_template_api_v1_admin_templates_assistants__template_id__delete
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      responses:
+        '204':
+          description: Successful Response
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    patch:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Update assistant template
+      description: Updates an existing assistant template (admin only)
+      operationId: update_template_api_v1_admin_templates_assistants__template_id__patch
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssistantTemplateAdminUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantTemplateAdminPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/templates/assistants/{template_id}/default':
+    patch:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Toggle assistant template as featured
+      description: |-
+        Toggle an assistant template as featured/default.
+
+        **Admin Only:** Requires admin permissions.
+
+        **Validation:**
+        - Template must belong to your tenant
+        - Maximum 5 featured templates per tenant
+        - Returns 400 if limit exceeded
+
+        **Behavior:**
+        - Featured templates appear first in the template gallery
+        - Featured templates are sorted alphabetically by name
+        - Non-featured templates appear below, sorted by creation date
+
+        **Example Request:**
+        ```json
+        {
+          "is_default": true
+        }
+        ```
+      operationId: >-
+        toggle_default_api_v1_admin_templates_assistants__template_id__default_patch
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssistantTemplateToggleDefaultRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantTemplateAdminPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/templates/assistants/{template_id}/rollback':
+    post:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Rollback assistant template
+      description: Restores template to original snapshot (admin only)
+      operationId: >-
+        rollback_template_api_v1_admin_templates_assistants__template_id__rollback_post
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantTemplateAdminPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/templates/assistants/{template_id}/restore':
+    post:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Restore deleted assistant template
+      description: Restores a soft-deleted template (admin only)
+      operationId: >-
+        restore_template_api_v1_admin_templates_assistants__template_id__restore_post
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantTemplateAdminPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/templates/assistants/{template_id}/permanent':
+    delete:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Permanently delete assistant template
+      description: Permanently removes a soft-deleted template from database (admin only)
+      operationId: >-
+        permanent_delete_template_api_v1_admin_templates_assistants__template_id__permanent_delete
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      responses:
+        '204':
+          description: Successful Response
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/templates/assistants/deleted:
+    get:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: List deleted assistant templates
+      description: Returns soft-deleted templates for audit trail (admin only)
+      operationId: list_deleted_templates_api_v1_admin_templates_assistants_deleted_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantTemplateAdminListPublic'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/templates/apps/:
+    get:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: List tenant's app templates
+      description: Returns all active app templates for your tenant (admin only)
+      operationId: list_templates_api_v1_admin_templates_apps__get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppTemplateAdminListPublic'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    post:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Create app template
+      description: |-
+        Create a new app template for your tenant.
+
+        **Admin Only:** Requires admin permissions.
+
+        **Prerequisites:**
+        - Feature flag `using_templates` must be enabled for your tenant
+        - Template name must be unique within your tenant
+
+        **Business Logic:**
+        - Template is automatically scoped to your tenant
+        - Original state is saved in `original_snapshot` for rollback
+        - Template immediately available in gallery for users in your tenant
+
+        **Example Request:**
+        ```json
+        {
+          "name": "Document Analyzer",
+          "description": "Analyzes uploaded documents and extracts key insights",
+          "category": "Analysis",
+          "prompt": "Analyze the following document and provide a summary with key insights.",
+          "completion_model_kwargs": {"temperature": 0.3, "max_tokens": 1000},
+          "wizard": {
+            "attachments": {"required": true, "title": "Upload document", "description": "Upload PDF or text file"},
+            "collections": null
+          },
+          "input_type": "file",
+          "input_description": "Upload a document (PDF, TXT, or DOCX)"
+        }
+        ```
+      operationId: create_template_api_v1_admin_templates_apps__post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AppTemplateAdminCreate'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppTemplateAdminPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '424':
+          description: Failed Dependency
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/templates/apps/{template_id}':
+    delete:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Delete app template
+      description: Soft-deletes an app template (admin only)
+      operationId: delete_template_api_v1_admin_templates_apps__template_id__delete
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      responses:
+        '204':
+          description: Successful Response
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    patch:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Update app template
+      description: Updates an existing app template (admin only)
+      operationId: update_template_api_v1_admin_templates_apps__template_id__patch
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AppTemplateAdminUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppTemplateAdminPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/templates/apps/{template_id}/default':
+    patch:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Toggle app template as featured
+      description: |-
+        Toggle an app template as featured/default.
+
+        **Admin Only:** Requires admin permissions.
+
+        **Validation:**
+        - Template must belong to your tenant
+        - Maximum 5 featured templates per tenant
+        - Returns 400 if limit exceeded
+
+        **Behavior:**
+        - Featured templates appear first in the template gallery
+        - Featured templates are sorted alphabetically by name
+        - Non-featured templates appear below, sorted by creation date
+
+        **Example Request:**
+        ```json
+        {
+          "is_default": true
+        }
+        ```
+      operationId: toggle_default_api_v1_admin_templates_apps__template_id__default_patch
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AppTemplateToggleDefaultRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppTemplateAdminPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/templates/apps/{template_id}/rollback':
+    post:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Rollback app template
+      description: Restores template to original snapshot (admin only)
+      operationId: >-
+        rollback_template_api_v1_admin_templates_apps__template_id__rollback_post
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppTemplateAdminPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/templates/apps/{template_id}/restore':
+    post:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Restore deleted app template
+      description: Restores a soft-deleted template (admin only)
+      operationId: restore_template_api_v1_admin_templates_apps__template_id__restore_post
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppTemplateAdminPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/templates/apps/{template_id}/permanent':
+    delete:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: Permanently delete app template
+      description: Permanently removes a soft-deleted template from database (admin only)
+      operationId: >-
+        permanent_delete_template_api_v1_admin_templates_apps__template_id__permanent_delete
+      parameters:
+        - name: template_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Template Id
+      responses:
+        '204':
+          description: Successful Response
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/templates/apps/deleted:
+    get:
+      tags:
+        - admin-templates
+        - admin-templates
+      summary: List deleted app templates
+      description: Returns soft-deleted templates for audit trail (admin only)
+      operationId: list_deleted_templates_api_v1_admin_templates_apps_deleted_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppTemplateAdminListPublic'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /jobs/:
     get:
       tags:
         - jobs
@@ -5013,14 +6846,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_JobPublic_"
+                $ref: '#/components/schemas/PaginatedResponse_JobPublic_'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/jobs/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/jobs/{id}/':
     get:
       tags:
         - jobs
@@ -5042,20 +6879,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/JobPublic"
+                $ref: '#/components/schemas/JobPublic'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/user-groups/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /user-groups/:
     get:
       tags:
         - user-groups
@@ -5067,13 +6908,17 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_UserGroupPublic_"
+                $ref: '#/components/schemas/PaginatedResponse_UserGroupPublic_'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - user-groups
@@ -5083,7 +6928,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/UserGroupCreateRequest"
+              $ref: '#/components/schemas/UserGroupCreateRequest'
         required: true
       responses:
         '200':
@@ -5091,20 +6936,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserGroupPublic"
+                $ref: '#/components/schemas/UserGroupPublic'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/user-groups/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/user-groups/{id}/':
     get:
       tags:
         - user-groups
@@ -5126,25 +6975,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserGroupPublic"
+                $ref: '#/components/schemas/UserGroupPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - user-groups
@@ -5164,7 +7017,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/UserGroupUpdateRequest"
+              $ref: '#/components/schemas/UserGroupUpdateRequest'
         required: true
       responses:
         '200':
@@ -5172,25 +7025,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserGroupPublic"
+                $ref: '#/components/schemas/UserGroupPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - user-groups
@@ -5212,26 +7069,30 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserGroupPublic"
+                $ref: '#/components/schemas/UserGroupPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/user-groups/{id}/users/{user_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/user-groups/{id}/users/{user_id}/':
     post:
       tags:
         - user-groups
@@ -5262,30 +7123,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserGroupPublic"
+                $ref: '#/components/schemas/UserGroupPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - user-groups
       summary: Delete User From User Group
-      operationId: delete_user_from_user_group_api_v1_user_groups__id__users__user_id___delete
+      operationId: >-
+        delete_user_from_user_group_api_v1_user_groups__id__users__user_id___delete
       parameters:
         - name: id
           in: path
@@ -5311,26 +7177,30 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserGroupPublic"
+                $ref: '#/components/schemas/UserGroupPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/allowed-origins/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /allowed-origins/:
     get:
       tags:
         - allowed-origins
@@ -5342,14 +7212,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_AllowedOriginPublic_"
+                $ref: '#/components/schemas/PaginatedResponse_AllowedOriginPublic_'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/completion-models/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /completion-models/:
     get:
       tags:
         - completion-models
@@ -5361,14 +7235,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_CompletionModelPublic_"
+                $ref: '#/components/schemas/PaginatedResponse_CompletionModelPublic_'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/completion-models/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/completion-models/{id}/':
     post:
       tags:
         - completion-models
@@ -5388,7 +7266,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/CompletionModelUpdateFlags"
+              $ref: '#/components/schemas/CompletionModelUpdateFlags'
         required: true
       responses:
         '200':
@@ -5396,26 +7274,437 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/CompletionModelPublic"
+                $ref: '#/components/schemas/CompletionModelPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/embedding-models/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/completion-models/{model_id}/usage':
+    get:
+      tags:
+        - completion-models
+      summary: Get Model Usage
+      description: >-
+        Get usage statistics for a specific model (pre-aggregated for
+        performance)
+      operationId: get_model_usage_api_v1_completion_models__model_id__usage_get
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Model Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelUsageStatistics'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/completion-models/{model_id}/usage/details':
+    get:
+      tags:
+        - completion-models
+      summary: Get Model Usage Details
+      description: Get detailed list of entities using this model with cursor pagination
+      operationId: >-
+        get_model_usage_details_api_v1_completion_models__model_id__usage_details_get
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Model Id
+        - name: entity_type
+          in: query
+          description: Filter by entity type
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: Filter by entity type
+            title: Entity Type
+        - name: cursor
+          in: query
+          description: Cursor for pagination
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: Cursor for pagination
+            title: Cursor
+        - name: limit
+          in: query
+          description: Number of results per page
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 50
+            description: Number of results per page
+            maximum: 100
+            title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResponse'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/completion-models/{model_id}/migrate':
+    post:
+      tags:
+        - completion-models
+      summary: Migrate Model Usage
+      description: Migrate all usage from one model to another with safety checks
+      operationId: migrate_model_usage_api_v1_completion_models__model_id__migrate_post
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Model Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelMigrationRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MigrationResult'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /completion-models/usage-summary:
+    get:
+      tags:
+        - completion-models
+      summary: Get All Models Usage Summary
+      description: Get usage summary for all models (optimized with pre-aggregation)
+      operationId: get_all_models_usage_summary_api_v1_completion_models_usage_summary_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ModelUsageSummary'
+                title: >-
+                  Response Get All Models Usage Summary Api V1 Completion Models
+                  Usage Summary Get
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/completion-models/{model_id}/migration-history':
+    get:
+      tags:
+        - completion-models
+      summary: Get Model Migration History
+      description: Get migration history for a specific model (from or to this model)
+      operationId: >-
+        get_model_migration_history_api_v1_completion_models__model_id__migration_history_get
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Model Id
+        - name: limit
+          in: query
+          description: Number of results per page
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 50
+            description: Number of results per page
+            maximum: 100
+            title: Limit
+        - name: offset
+          in: query
+          description: Offset for pagination
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 0
+            description: Offset for pagination
+            minimum: 0
+            title: Offset
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ModelMigrationHistory'
+                title: >-
+                  Response Get Model Migration History Api V1 Completion Models 
+                  Model Id  Migration History Get
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /completion-models/migration-history:
+    get:
+      tags:
+        - completion-models
+      summary: Get All Migration History
+      description: Get all migration history for the tenant
+      operationId: get_all_migration_history_api_v1_completion_models_migration_history_get
+      parameters:
+        - name: limit
+          in: query
+          description: Number of results per page
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 50
+            description: Number of results per page
+            maximum: 100
+            title: Limit
+        - name: offset
+          in: query
+          description: Offset for pagination
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 0
+            description: Offset for pagination
+            minimum: 0
+            title: Offset
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ModelMigrationHistory'
+                title: >-
+                  Response Get All Migration History Api V1 Completion Models
+                  Migration History Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/completion-models/migration-history/{migration_id}':
+    get:
+      tags:
+        - completion-models
+      summary: Get Migration History By Id
+      description: Get a specific migration history record by ID
+      operationId: >-
+        get_migration_history_by_id_api_v1_completion_models_migration_history__migration_id__get
+      parameters:
+        - name: migration_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Migration Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelMigrationHistory'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /embedding-models/:
     get:
       tags:
         - embedding-models
@@ -5427,14 +7716,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_EmbeddingModelPublic_"
+                $ref: '#/components/schemas/PaginatedResponse_EmbeddingModelPublic_'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/embedding-models/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/embedding-models/{id}/':
     get:
       tags:
         - embedding-models
@@ -5456,25 +7749,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/EmbeddingModelPublic"
+                $ref: '#/components/schemas/EmbeddingModelPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - embedding-models
@@ -5494,7 +7791,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/EmbeddingModelUpdate"
+              $ref: '#/components/schemas/EmbeddingModelUpdate'
         required: true
       responses:
         '200':
@@ -5502,26 +7799,30 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/EmbeddingModelPublic"
+                $ref: '#/components/schemas/EmbeddingModelPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/transcription-models/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /transcription-models/:
     get:
       tags:
         - transcription-models
@@ -5533,14 +7834,19 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_TranscriptionModelPublic_"
+                $ref: >-
+                  #/components/schemas/PaginatedResponse_TranscriptionModelPublic_
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/transcription-models/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/transcription-models/{id}/':
     post:
       tags:
         - transcription-models
@@ -5560,7 +7866,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/TranscriptionModelUpdate"
+              $ref: '#/components/schemas/TranscriptionModelUpdate'
         required: true
       responses:
         '200':
@@ -5568,26 +7874,726 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/TranscriptionModelPublic"
+                $ref: '#/components/schemas/TranscriptionModelPublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/files/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/model-providers/:
+    get:
+      tags:
+        - admin
+        - model-providers
+      summary: List Providers
+      description: List all model providers for the tenant.
+      operationId: list_providers_api_v1_admin_model_providers__get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ModelProviderPublic'
+                title: Response List Providers Api V1 Admin Model Providers  Get
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    post:
+      tags:
+        - admin
+        - model-providers
+      summary: Create Provider
+      description: Create a new model provider.
+      operationId: create_provider_api_v1_admin_model_providers__post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelProviderCreate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelProviderPublic'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/model-providers/{provider_id}/':
+    get:
+      tags:
+        - admin
+        - model-providers
+      summary: Get Provider
+      description: Get a specific model provider.
+      operationId: get_provider_api_v1_admin_model_providers__provider_id___get
+      parameters:
+        - name: provider_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Provider Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelProviderPublic'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    put:
+      tags:
+        - admin
+        - model-providers
+      summary: Update Provider
+      description: Update an existing model provider.
+      operationId: update_provider_api_v1_admin_model_providers__provider_id___put
+      parameters:
+        - name: provider_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Provider Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelProviderUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelProviderPublic'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    delete:
+      tags:
+        - admin
+        - model-providers
+      summary: Delete Provider
+      description: |-
+        Delete a model provider.
+
+        Will fail if the provider has models attached to it.
+      operationId: delete_provider_api_v1_admin_model_providers__provider_id___delete
+      parameters:
+        - name: provider_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Provider Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/tenant-models/completion/:
+    post:
+      tags:
+        - admin
+        - tenant-models
+      summary: Create Tenant Completion Model
+      description: Create a new tenant-specific completion model.
+      operationId: >-
+        create_tenant_completion_model_api_v1_admin_tenant_models_completion__post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantCompletionModelCreate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompletionModelPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/tenant-models/completion/{model_id}/':
+    put:
+      tags:
+        - admin
+        - tenant-models
+      summary: Update Tenant Completion Model
+      description: Update a tenant-specific completion model.
+      operationId: >-
+        update_tenant_completion_model_api_v1_admin_tenant_models_completion__model_id___put
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Model Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantCompletionModelUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompletionModelPublic'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    delete:
+      tags:
+        - admin
+        - tenant-models
+      summary: Delete Tenant Completion Model
+      description: Delete a tenant-specific completion model.
+      operationId: >-
+        delete_tenant_completion_model_api_v1_admin_tenant_models_completion__model_id___delete
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Model Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/tenant-models/embedding/:
+    post:
+      tags:
+        - admin
+        - tenant-models
+      summary: Create Tenant Embedding Model
+      description: Create a new tenant-specific embedding model.
+      operationId: create_tenant_embedding_model_api_v1_admin_tenant_models_embedding__post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantEmbeddingModelCreate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddingModelPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/tenant-models/embedding/{model_id}/':
+    put:
+      tags:
+        - admin
+        - tenant-models
+      summary: Update Tenant Embedding Model
+      description: Update a tenant-specific embedding model.
+      operationId: >-
+        update_tenant_embedding_model_api_v1_admin_tenant_models_embedding__model_id___put
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Model Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantEmbeddingModelUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddingModelPublic'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    delete:
+      tags:
+        - admin
+        - tenant-models
+      summary: Delete Tenant Embedding Model
+      description: Delete a tenant-specific embedding model.
+      operationId: >-
+        delete_tenant_embedding_model_api_v1_admin_tenant_models_embedding__model_id___delete
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Model Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/tenant-models/transcription/:
+    post:
+      tags:
+        - admin
+        - tenant-models
+      summary: Create Tenant Transcription Model
+      description: Create a new tenant-specific transcription model.
+      operationId: >-
+        create_tenant_transcription_model_api_v1_admin_tenant_models_transcription__post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantTranscriptionModelCreate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranscriptionModelPublic'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/tenant-models/transcription/{model_id}/':
+    put:
+      tags:
+        - admin
+        - tenant-models
+      summary: Update Tenant Transcription Model
+      description: Update a tenant-specific transcription model.
+      operationId: >-
+        update_tenant_transcription_model_api_v1_admin_tenant_models_transcription__model_id___put
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Model Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantTranscriptionModelUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranscriptionModelPublic'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    delete:
+      tags:
+        - admin
+        - tenant-models
+      summary: Delete Tenant Transcription Model
+      description: Delete a tenant-specific transcription model.
+      operationId: >-
+        delete_tenant_transcription_model_api_v1_admin_tenant_models_transcription__model_id___delete
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Model Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /files/:
     get:
       tags:
         - files
@@ -5599,13 +8605,17 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_FilePublic_"
+                $ref: '#/components/schemas/PaginatedResponse_FilePublic_'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - files
@@ -5615,7 +8625,7 @@ paths:
         content:
           multipart/form-data:
             schema:
-              "$ref": "#/components/schemas/Body_upload_file_api_v1_files__post"
+              $ref: '#/components/schemas/Body_upload_file_api_v1_files__post'
         required: true
       responses:
         '200':
@@ -5623,32 +8633,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/FilePublic"
+                $ref: '#/components/schemas/FilePublic'
         '413':
           description: Request Entity Too Large
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '415':
           description: Unsupported Media Type
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/files/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/files/{id}/':
     get:
       tags:
         - files
@@ -5670,19 +8684,23 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/FilePublic"
+                $ref: '#/components/schemas/FilePublic'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - files
@@ -5706,20 +8724,25 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/files/{id}/signed-url/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/files/{id}/signed-url/':
     post:
       tags:
         - files
       summary: Generate a signed URL for file download
-      description: |-
-        Generates a signed URL that can be used to download a file without authentication.
+      description: >-
+        Generates a signed URL that can be used to download a file without
+        authentication.
             The URL will expire after the specified time period.
 
             This is useful for sharing files with third parties or for embedding in emails.
@@ -5738,7 +8761,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SignedURLRequest"
+              $ref: '#/components/schemas/SignedURLRequest'
         required: true
       responses:
         '200':
@@ -5746,20 +8769,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SignedURLResponse"
+                $ref: '#/components/schemas/SignedURLResponse'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/files/{id}/download/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/files/{id}/download/':
     get:
       tags:
         - files
@@ -5802,8 +8829,9 @@ paths:
         '206':
           description: Successfully downloaded a partial content (range request)
         '400':
-          description: Bad request - Invalid token or range requests not supported
-            for this file type
+          description: >-
+            Bad request - Invalid token or range requests not supported for this
+            file type
         '401':
           description: Unauthorized - Token is invalid or has expired
         '403':
@@ -5817,12 +8845,143 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - default: []
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/icons/{id}/':
+    get:
+      tags:
+        - icons
+      summary: Get icon image
+      description: >-
+        Returns icon as binary data. Public endpoint for img tags. Cached for 1
+        year.
+      operationId: get_icon_api_v1_icons__id___get
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            image/png: {}
+            image/jpeg: {}
+            image/webp: {}
+        '404':
+          description: Icon not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/limits/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    delete:
+      tags:
+        - icons
+      summary: Delete icon
+      description: Delete an icon by ID. Requires authentication and ownership.
+      operationId: delete_icon_api_v1_icons__id___delete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /icons/:
+    post:
+      tags:
+        - icons
+      summary: Upload icon
+      description: 'Upload icon image (PNG, JPEG, WebP). Max 256 KB. Returns icon ID.'
+      operationId: create_icon_api_v1_icons__post
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Body_create_icon_api_v1_icons__post'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IconPublic'
+        '413':
+          description: Request Entity Too Large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '415':
+          description: Unsupported Media Type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /limits/:
     get:
       tags:
         - limits
@@ -5834,30 +8993,67 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Limits"
+                $ref: '#/components/schemas/Limits'
       security:
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /spaces/:
     get:
       tags:
         - spaces
       summary: Get Spaces
       operationId: get_spaces_api_v1_spaces__get
+      parameters:
+        - name: include_applications
+          in: query
+          description: Includes published applications on each space
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: boolean
+            default: false
+            description: Includes published applications on each space
+            title: Include Applications
+        - name: include_personal
+          in: query
+          description: Includes your personal space
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: boolean
+            default: false
+            description: Includes your personal space
+            title: Include Personal
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_SpaceSparse_"
+                $ref: '#/components/schemas/PaginatedResponse_SpaceSparse_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - spaces
@@ -5867,7 +9063,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/CreateSpaceRequest"
+              $ref: '#/components/schemas/CreateSpaceRequest'
         required: true
       responses:
         '201':
@@ -5875,20 +9071,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SpacePublic"
+                $ref: '#/components/schemas/SpacePublic'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/':
     get:
       tags:
         - spaces
@@ -5910,25 +9110,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SpacePublic"
+                $ref: '#/components/schemas/SpacePublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - spaces
@@ -5952,25 +9156,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     patch:
       tags:
         - spaces
@@ -5990,7 +9198,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/PartialUpdateSpaceRequest"
+              $ref: '#/components/schemas/PartialUpdateSpaceRequest'
         required: true
       responses:
         '200':
@@ -5998,45 +9206,51 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SpacePublic"
+                $ref: '#/components/schemas/SpacePublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/security_classification/{security_classification_id}/impact-analysis/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/security_classification/{security_classification_id}/impact-analysis/':
     get:
       tags:
         - spaces
       summary: Get Security Classification Impact Analysis
-      description: Get a preview of the impact of changing the security classification
-        of a space.
-      operationId: get_security_classification_impact_analysis_api_v1_spaces__id__security_classification__security_classification_id__impact_analysis__get
+      description: >-
+        Get a preview of the impact of changing the security classification of a
+        space.
+      operationId: >-
+        get_security_classification_impact_analysis_api_v1_spaces__id__security_classification__security_classification_id__impact_analysis__get
       parameters:
         - name: id
           in: path
@@ -6062,20 +9276,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UpdateSpaceDryRunResponse"
+                $ref: '#/components/schemas/UpdateSpaceDryRunResponse'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/applications/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/applications/':
     get:
       tags:
         - spaces
@@ -6097,26 +9315,30 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Applications"
+                $ref: '#/components/schemas/Applications'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/applications/assistants/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/applications/assistants/':
     post:
       tags:
         - spaces
@@ -6136,7 +9358,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/CreateSpaceAssistantRequest"
+              $ref: '#/components/schemas/CreateSpaceAssistantRequest'
         required: true
       responses:
         '201':
@@ -6144,38 +9366,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AssistantPublic"
+                $ref: '#/components/schemas/AssistantPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/applications/group-chats/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/applications/group-chats/':
     post:
       tags:
         - spaces
@@ -6196,7 +9422,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/GroupChatCreate"
+              $ref: '#/components/schemas/GroupChatCreate'
         required: true
       responses:
         '201':
@@ -6204,38 +9430,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GroupChatPublic"
+                $ref: '#/components/schemas/GroupChatPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/applications/apps/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/applications/apps/':
     post:
       tags:
         - spaces
@@ -6255,7 +9485,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/CreateSpaceAppRequest"
+              $ref: '#/components/schemas/CreateSpaceAppRequest'
         required: true
       responses:
         '201':
@@ -6263,38 +9493,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AppPublic"
+                $ref: '#/components/schemas/AppPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/applications/services/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/applications/services/':
     post:
       tags:
         - spaces
@@ -6314,7 +9548,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/CreateSpaceServiceRequest"
+              $ref: '#/components/schemas/CreateSpaceServiceRequest'
         required: true
       responses:
         '201':
@@ -6322,38 +9556,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/CreateSpaceServiceResponse"
+                $ref: '#/components/schemas/CreateSpaceServiceResponse'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/knowledge/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/knowledge/':
     get:
       tags:
         - spaces
@@ -6375,26 +9613,30 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Knowledge"
+                $ref: '#/components/schemas/Knowledge'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/knowledge/groups/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/knowledge/groups/':
     post:
       tags:
         - spaces
@@ -6414,7 +9656,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/CreateSpaceGroupsRequest"
+              $ref: '#/components/schemas/CreateSpaceGroupsRequest'
         required: true
       responses:
         '201':
@@ -6422,42 +9664,68 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/CollectionPublic"
+                $ref: '#/components/schemas/CollectionPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/knowledge/websites/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/knowledge/websites/':
     post:
       tags:
         - spaces
-      summary: Create Space Websites
+      summary: Create a website crawler
+      description: >-
+        Create a new website crawler that will extract content and make it
+        available to assistants in this space.
+
+            **Update Intervals:**
+            - `never` (default): Manual crawls only
+            - `daily`: Automatic recrawl every day at 3 AM Swedish time
+            - `every_other_day`: Recrawl every 2 days
+            - `weekly`: Recrawl every Friday
+
+            **Example Request Body:**
+            ```json
+            {
+              "name": "Company Documentation",
+              "url": "https://docs.example.com",
+              "crawl_type": "crawl",
+              "download_files": true,
+              "update_interval": "daily"
+            }
+            ```
+
+            The crawl will start immediately upon creation.
       operationId: create_space_websites_api_v1_spaces__id__knowledge_websites__post
       parameters:
         - name: id
@@ -6473,7 +9741,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/WebsiteCreate"
+              $ref: '#/components/schemas/WebsiteCreate'
         required: true
       responses:
         '201':
@@ -6481,43 +9749,48 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/WebsitePublic"
+                $ref: '#/components/schemas/WebsitePublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/knowledge/integrations/{user_integration_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/knowledge/integrations/add/{user_integration_id}/':
     post:
       tags:
         - spaces
       summary: Create Space Integration Knowledge
-      operationId: create_space_integration_knowledge_api_v1_spaces__id__knowledge_integrations__user_integration_id___post
+      operationId: >-
+        create_space_integration_knowledge_api_v1_spaces__id__knowledge_integrations_add__user_integration_id___post
       parameters:
         - name: id
           in: path
@@ -6541,32 +9814,94 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/CreateSpaceIntegrationKnowledge"
+              $ref: '#/components/schemas/CreateSpaceIntegrationKnowledge'
         required: true
       responses:
-        '200':
+        '202':
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/JobPublic'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/knowledge/{integration_knowledge_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/knowledge/integrations/add/{user_integration_id}/batch/':
+    post:
+      tags:
+        - spaces
+      summary: Create Space Integration Knowledge Batch
+      operationId: >-
+        create_space_integration_knowledge_batch_api_v1_spaces__id__knowledge_integrations_add__user_integration_id__batch__post
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+        - name: user_integration_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: User Integration Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSpaceIntegrationKnowledgeBatchRequest'
+        required: true
+      responses:
+        '202':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: >-
+                  #/components/schemas/CreateSpaceIntegrationKnowledgeBatchResponse
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/knowledge/integrations/remove/{integration_knowledge_id}/':
     delete:
       tags:
         - spaces
       summary: Delete Space Integration Knowledge
-      operationId: delete_space_integration_knowledge_api_v1_spaces__id__knowledge__integration_knowledge_id___delete
+      operationId: >-
+        delete_space_integration_knowledge_api_v1_spaces__id__knowledge_integrations_remove__integration_knowledge_id___delete
       parameters:
         - name: id
           in: path
@@ -6594,14 +9929,226 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/members/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/knowledge/integrations/wrappers/{wrapper_id}/':
+    delete:
+      tags:
+        - spaces
+      summary: Delete Integration Knowledge Wrapper
+      operationId: >-
+        delete_integration_knowledge_wrapper_api_v1_spaces__id__knowledge_integrations_wrappers__wrapper_id___delete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+        - name: wrapper_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Wrapper Id
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    patch:
+      tags:
+        - spaces
+      summary: Update Integration Knowledge Wrapper
+      operationId: >-
+        update_integration_knowledge_wrapper_api_v1_spaces__id__knowledge_integrations_wrappers__wrapper_id___patch
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+        - name: wrapper_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Wrapper Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateIntegrationKnowledgeWrapperRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/IntegrationKnowledgePublic'
+                title: >-
+                  Response Update Integration Knowledge Wrapper Api V1 Spaces 
+                  Id  Knowledge Integrations Wrappers  Wrapper Id   Patch
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/knowledge/integrations/{integration_knowledge_id}/':
+    patch:
+      tags:
+        - spaces
+      summary: Update Integration Knowledge
+      operationId: >-
+        update_integration_knowledge_api_v1_spaces__id__knowledge_integrations__integration_knowledge_id___patch
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+        - name: integration_knowledge_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Integration Knowledge Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateIntegrationKnowledgeRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationKnowledgePublic'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/knowledge/integrations/{integration_knowledge_id}/sync/':
+    post:
+      tags:
+        - spaces
+      summary: Trigger Integration Full Sync
+      operationId: >-
+        trigger_integration_full_sync_api_v1_spaces__id__knowledge_integrations__integration_knowledge_id__sync__post
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+        - name: integration_knowledge_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Integration Knowledge Id
+      responses:
+        '202':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobPublic'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/members/':
     post:
       tags:
         - spaces
@@ -6621,7 +10168,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/AddSpaceMemberRequest"
+              $ref: '#/components/schemas/AddSpaceMemberRequest'
         required: true
       responses:
         '200':
@@ -6629,32 +10176,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SpaceMember"
+                $ref: '#/components/schemas/SpaceMember'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/{id}/members/{user_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/members/{user_id}/':
     delete:
       tags:
         - spaces
@@ -6687,31 +10238,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     patch:
       tags:
         - spaces
@@ -6740,7 +10295,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/UpdateSpaceMemberRequest"
+              $ref: '#/components/schemas/UpdateSpaceMemberRequest'
         required: true
       responses:
         '200':
@@ -6748,38 +10303,308 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SpaceMember"
+                $ref: '#/components/schemas/SpaceMember'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/spaces/type/personal/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/group-members/':
+    get:
+      tags:
+        - spaces
+      summary: Get Space Group Members
+      description: List all user groups that are members of this space.
+      operationId: get_space_group_members_api_v1_spaces__id__group_members__get
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResponse_SpaceGroupMember_'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    post:
+      tags:
+        - spaces
+      summary: Add Space Group Member
+      description: >-
+        Add a user group to a space with the specified role.
+
+
+        All members of the group will gain access to the space at that role
+        level.
+
+        Groups cannot be added to personal spaces.
+      operationId: add_space_group_member_api_v1_spaces__id__group_members__post
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddSpaceGroupMemberRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpaceGroupMember'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/spaces/{id}/group-members/{group_id}/':
+    delete:
+      tags:
+        - spaces
+      summary: Remove Space Group Member
+      description: >-
+        Remove a user group from a space.
+
+
+        All members of the group will lose access through this group membership.
+
+        Note: Users may still have access through direct membership or other
+        groups.
+      operationId: >-
+        remove_space_group_member_api_v1_spaces__id__group_members__group_id___delete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+        - name: group_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Group Id
+      responses:
+        '204':
+          description: Successful Response
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    patch:
+      tags:
+        - spaces
+      summary: Change Group Member Role
+      description: Change the role of a user group in a space.
+      operationId: >-
+        change_group_member_role_api_v1_spaces__id__group_members__group_id___patch
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Id
+        - name: group_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Group Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSpaceGroupMemberRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpaceGroupMember'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /spaces/type/personal/:
     get:
       tags:
         - spaces
@@ -6791,14 +10616,41 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SpacePublic"
+                $ref: '#/components/schemas/SpacePublic'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/dashboard/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /spaces/type/organization/:
+    get:
+      tags:
+        - spaces
+      summary: Get Organization Space
+      operationId: get_organization_space_api_v1_spaces_type_organization__get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpacePublic'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /dashboard/:
     get:
       tags:
         - dashboard
@@ -6820,20 +10672,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Dashboard"
+                $ref: '#/components/schemas/Dashboard'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/websites/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /websites/:
     get:
       tags:
         - websites
@@ -6842,12 +10698,14 @@ paths:
       parameters:
         - name: for_tenant
           in: query
+          description: Filter websites by tenant scope
           required: false
           style: form
           explode: true
           schema:
             type: boolean
             default: false
+            description: Filter websites by tenant scope
             title: For Tenant
       responses:
         '200':
@@ -6855,13 +10713,13 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_WebsitePublic_"
+                $ref: '#/components/schemas/PaginatedResponse_WebsitePublic_'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       deprecated: true
       security:
         - OAuth2PasswordBearer: []
@@ -6869,6 +10727,10 @@ paths:
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - websites
@@ -6878,7 +10740,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/WebsiteCreateRequestDeprecated"
+              $ref: '#/components/schemas/WebsiteCreateRequestDeprecated'
         required: true
       responses:
         '200':
@@ -6886,13 +10748,13 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/WebsitePublic"
+                $ref: '#/components/schemas/WebsitePublic'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       deprecated: true
       security:
         - OAuth2PasswordBearer: []
@@ -6900,7 +10762,153 @@ paths:
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/websites/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /websites/check-url/:
+    get:
+      tags:
+        - websites
+      summary: Check if URL exists on Organization space
+      description: |-
+        Check if a website URL already exists on the user's Organization space.
+
+            **Use case:**
+            When creating a new website on a Personal or Shared space, call this endpoint
+            to check if the URL is already being crawled on the Organization space.
+            This helps avoid duplicate crawls and informs users that the knowledge
+            might already be available for import.
+
+            **Returns:**
+            - Website info if URL exists on Organization space
+            - `null` if URL not found or user has no Organization space
+
+            **Note:** This does not block website creation - it's informational only.
+      operationId: check_existing_website_url_api_v1_websites_check_url__get
+      parameters:
+        - name: url
+          in: query
+          description: The website URL to check
+          required: true
+          style: form
+          explode: true
+          schema:
+            type: string
+            description: The website URL to check
+            title: Url
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/WebsiteExistsResponse'
+                  - type: 'null'
+                title: >-
+                  Response Check Existing Website Url Api V1 Websites Check Url 
+                  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /websites/bulk/run/:
+    post:
+      tags:
+        - websites
+      summary: Trigger bulk crawl
+      description: |-
+        Trigger crawls for multiple websites at once. Useful for:
+            - Batch recrawling selected websites
+            - Refreshing multiple knowledge sources simultaneously
+            - Recovering from failed crawls across multiple sites
+
+            **Features:**
+            - Maximum 50 websites per request (safety limit)
+            - Individual failures don't stop the batch
+            - Returns detailed status for each website
+
+            **Example Request:**
+            ```json
+            {
+              "website_ids": [
+                "123e4567-e89b-12d3-a456-426614174000",
+                "123e4567-e89b-12d3-a456-426614174001"
+              ]
+            }
+            ```
+
+            **Example Response:**
+            ```json
+            {
+              "total": 2,
+              "queued": 1,
+              "failed": 1,
+              "crawl_runs": [...],
+              "errors": [
+                {
+                  "website_id": "123e4567-e89b-12d3-a456-426614174001",
+                  "error": "Crawl already in progress for this website"
+                }
+              ]
+            }
+            ```
+      operationId: bulk_run_crawl_api_v1_websites_bulk_run__post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkCrawlRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkCrawlResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/websites/{id}/':
     get:
       tags:
         - websites
@@ -6909,12 +10917,14 @@ paths:
       parameters:
         - name: id
           in: path
+          description: Unique identifier of the website
           required: true
           style: simple
           explode: false
           schema:
             type: string
             format: uuid
+            description: Unique identifier of the website
             title: Id
       responses:
         '200':
@@ -6922,25 +10932,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/WebsitePublic"
+                $ref: '#/components/schemas/WebsitePublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - websites
@@ -6949,18 +10963,20 @@ paths:
       parameters:
         - name: id
           in: path
+          description: Unique identifier of the website to update
           required: true
           style: simple
           explode: false
           schema:
             type: string
             format: uuid
+            description: Unique identifier of the website to update
             title: Id
       requestBody:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/WebsiteUpdate"
+              $ref: '#/components/schemas/WebsiteUpdate'
         required: true
       responses:
         '200':
@@ -6968,25 +10984,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/WebsitePublic"
+                $ref: '#/components/schemas/WebsitePublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - websites
@@ -6995,49 +11015,75 @@ paths:
       parameters:
         - name: id
           in: path
+          description: Unique identifier of the website to delete
           required: true
           style: simple
           explode: false
           schema:
             type: string
             format: uuid
+            description: Unique identifier of the website to delete
             title: Id
       responses:
-        '204':
+        '200':
           description: Successful Response
+          content:
+            application/json:
+              schema: {}
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/websites/{id}/run/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/websites/{id}/run/':
     post:
       tags:
         - websites
-      summary: Run Crawl
+      summary: Trigger a crawl
+      description: |-
+        Manually trigger a crawl for a specific website. This can be used to:
+            - Recrawl a website to update its content
+            - Force a crawl outside the automatic update schedule
+            - Retry a failed crawl
+
+            The crawl will use the website's configured settings (crawler engine, crawl type, etc.).
+
+            **Status Flow:**
+            1. `queued` - Crawl is waiting to start
+            2. `in progress` - Crawl is actively running
+            3. `complete` - Crawl finished successfully
+            4. `failed` - Crawl encountered an error
+
+            Returns the new crawl run with status information.
       operationId: run_crawl_api_v1_websites__id__run__post
       parameters:
         - name: id
           in: path
+          description: Unique identifier of the website to crawl
           required: true
           style: simple
           explode: false
           schema:
             type: string
             format: uuid
+            description: Unique identifier of the website to crawl
             title: Id
       responses:
         '200':
@@ -7045,32 +11091,37 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/intric__websites__presentation__website_models__CrawlRunPublic"
+                $ref: >-
+                  #/components/schemas/intric__websites__presentation__website_models__CrawlRunPublic
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/websites/{id}/runs/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/websites/{id}/runs/':
     get:
       tags:
         - websites
@@ -7079,12 +11130,14 @@ paths:
       parameters:
         - name: id
           in: path
+          description: Unique identifier of the website
           required: true
           style: simple
           explode: false
           schema:
             type: string
             format: uuid
+            description: Unique identifier of the website
             title: Id
       responses:
         '200':
@@ -7092,20 +11145,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_CrawlRunPublic_"
+                $ref: '#/components/schemas/PaginatedResponse_CrawlRunPublic_'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/websites/{id}/transfer/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/websites/{id}/transfer/':
     post:
       tags:
         - websites
@@ -7114,18 +11171,20 @@ paths:
       parameters:
         - name: id
           in: path
+          description: Unique identifier of the website to transfer
           required: true
           style: simple
           explode: false
           schema:
             type: string
             format: uuid
+            description: Unique identifier of the website to transfer
             title: Id
       requestBody:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/TransferRequest"
+              $ref: '#/components/schemas/TransferRequest'
         required: true
       responses:
         '204':
@@ -7135,14 +11194,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/websites/{id}/info-blobs/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/websites/{id}/info-blobs/':
     get:
       tags:
         - websites
@@ -7151,12 +11214,14 @@ paths:
       parameters:
         - name: id
           in: path
+          description: Unique identifier of the website
           required: true
           style: simple
           explode: false
           schema:
             type: string
             format: uuid
+            description: Unique identifier of the website
             title: Id
       responses:
         '200':
@@ -7164,32 +11229,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PaginatedResponse_InfoBlobPublicNoText_"
+                $ref: '#/components/schemas/PaginatedResponse_InfoBlobPublicNoText_'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/prompts/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/prompts/{id}/':
     get:
       tags:
         - prompts
@@ -7211,37 +11280,41 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PromptPublic"
+                $ref: '#/components/schemas/PromptPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - prompts
@@ -7265,25 +11338,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     patch:
       tags:
         - prompts
@@ -7303,7 +11380,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/PromptUpdateRequest"
+              $ref: '#/components/schemas/PromptUpdateRequest'
         required: true
       responses:
         '200':
@@ -7311,43 +11388,70 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PromptPublic"
+                $ref: '#/components/schemas/PromptPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/templates/apps/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /templates/apps/:
     get:
       tags:
         - apps-templates
-      summary: Get Templates
-      description: Get all app templates
+      summary: List available app templates
+      description: >-
+        Get app templates available for creating new apps.
+
+
+        **Feature Flag Behavior:**
+
+        - If `using_templates` feature is disabled: Returns empty list (not an
+        error)
+
+        - If `using_templates` feature is enabled: Returns all available
+        templates
+
+
+        **Template Scope:**
+
+        - Global templates (tenant_id = NULL): Available to all tenants
+
+        - Tenant-specific templates: Only available to that tenant
+
+
+        **Response:**
+
+        Returns paginated list of templates with basic information for gallery
+        display.
       operationId: get_templates_api_v1_templates_apps__get
       responses:
         '200':
@@ -7355,31 +11459,52 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AppTemplateListPublic"
-        '400':
-          description: Bad Request
+                $ref: '#/components/schemas/AppTemplateListPublic'
+        '401':
+          description: Unauthorized
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
-        '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/templates/assistants/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /templates/assistants/:
     get:
       tags:
         - assistants-templates
-      summary: Get Templates
-      description: Get all assistant templates
+      summary: List available assistant templates
+      description: >-
+        Get assistant templates available for creating new assistants.
+
+
+        **Feature Flag Behavior:**
+
+        - If `using_templates` feature is disabled: Returns empty list (not an
+        error)
+
+        - If `using_templates` feature is enabled: Returns all available
+        templates
+
+
+        **Template Scope:**
+
+        - Global templates (tenant_id = NULL): Available to all tenants
+
+        - Tenant-specific templates: Only available to that tenant
+
+
+        **Response:**
+
+        Returns paginated list of templates with basic information for gallery
+        display.
       operationId: get_templates_api_v1_templates_assistants__get
       responses:
         '200':
@@ -7387,26 +11512,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AssistantTemplateListPublic"
-        '400':
-          description: Bad Request
+                $ref: '#/components/schemas/AssistantTemplateListPublic'
+        '401':
+          description: Unauthorized
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
-        '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/templates/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /templates/:
     get:
       tags:
         - templates
@@ -7419,14 +11542,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/TemplateListPublic"
+                $ref: '#/components/schemas/TemplateListPublic'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/storage/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /storage/:
     get:
       tags:
         - storage
@@ -7438,14 +11565,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/StorageModel"
+                $ref: '#/components/schemas/StorageModel'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/storage/spaces/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /storage/spaces/:
     get:
       tags:
         - storage
@@ -7457,27 +11588,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/StorageInfoModel"
+                $ref: '#/components/schemas/StorageInfoModel'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/token-usage/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /token-usage/:
     get:
       tags:
         - token-usage
       summary: Get Token Usage
-      description: |-
+      description: >-
         Get token usage statistics for the specified date range.
+
         If no dates are provided, returns token usage for the last 30 days.
-        Note: If no time is provided in datetime parameters, time components default to 00:00:00.
+
+        Note: If no time is provided in datetime parameters, time components
+        default to 00:00:00.
       operationId: get_token_usage_api_v1_token_usage__get
       parameters:
         - name: start_date
           in: query
-          description: Start date for token usage data (defaults to 30 days ago).Time
+          description: >-
+            Start date for token usage data (defaults to 30 days ago).Time
             defaults to 00:00:00.
           required: false
           style: form
@@ -7487,12 +11626,14 @@ paths:
               - type: string
                 format: date-time
               - type: 'null'
-            description: Start date for token usage data (defaults to 30 days ago).Time
+            description: >-
+              Start date for token usage data (defaults to 30 days ago).Time
               defaults to 00:00:00.
             title: Start Date
         - name: end_date
           in: query
-          description: End date for token usage data (defaults to current time).Time
+          description: >-
+            End date for token usage data (defaults to current time).Time
             defaults to 00:00:00.
           required: false
           style: form
@@ -7502,7 +11643,8 @@ paths:
               - type: string
                 format: date-time
               - type: 'null'
-            description: End date for token usage data (defaults to current time).Time
+            description: >-
+              End date for token usage data (defaults to current time).Time
               defaults to 00:00:00.
             title: End Date
       responses:
@@ -7511,33 +11653,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/TokenUsageSummary"
+                $ref: '#/components/schemas/TokenUsageSummary'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/token-usage/users":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /token-usage/users:
     get:
       tags:
         - token-usage
       summary: Get User Token Usage
-      description: |-
-        Get token usage statistics aggregated by user for the specified date range.
+      description: >-
+        Get token usage statistics aggregated by user for the specified date
+        range.
+
         If no dates are provided, returns token usage for the last 30 days.
-        Note: If no time is provided in datetime parameters, time components default to 00:00:00.
+
+        Note: If no time is provided in datetime parameters, time components
+        default to 00:00:00.
       operationId: get_user_token_usage_api_v1_token_usage_users_get
       parameters:
         - name: start_date
           in: query
-          description: Start date for token usage data (defaults to 30 days ago).Time
+          description: >-
+            Start date for token usage data (defaults to 30 days ago).Time
             defaults to 00:00:00.
           required: false
           style: form
@@ -7547,12 +11698,14 @@ paths:
               - type: string
                 format: date-time
               - type: 'null'
-            description: Start date for token usage data (defaults to 30 days ago).Time
+            description: >-
+              Start date for token usage data (defaults to 30 days ago).Time
               defaults to 00:00:00.
             title: Start Date
         - name: end_date
           in: query
-          description: End date for token usage data (defaults to current time).Time
+          description: >-
+            End date for token usage data (defaults to current time).Time
             defaults to 00:00:00.
           required: false
           style: form
@@ -7562,7 +11715,8 @@ paths:
               - type: string
                 format: date-time
               - type: 'null'
-            description: End date for token usage data (defaults to current time).Time
+            description: >-
+              End date for token usage data (defaults to current time).Time
               defaults to 00:00:00.
             title: End Date
         - name: page
@@ -7594,7 +11748,7 @@ paths:
           style: form
           explode: true
           schema:
-            "$ref": "#/components/schemas/UserSortBy"
+            $ref: '#/components/schemas/UserSortBy'
             default: total_tokens
             description: Field to sort by.
         - name: sort_order
@@ -7614,28 +11768,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserTokenUsageSummary"
+                $ref: '#/components/schemas/UserTokenUsageSummary'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/token-usage/users/{user_id}/summary":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/token-usage/users/{user_id}/summary':
     get:
       tags:
         - token-usage
       summary: Get User Summary
-      description: |-
+      description: >-
         Get summary for a specific user without fetching all users.
+
         If no dates are provided, returns summary for the last 30 days.
-        Note: If no time is provided in datetime parameters, time components default to 00:00:00.
+
+        Note: If no time is provided in datetime parameters, time components
+        default to 00:00:00.
       operationId: get_user_summary_api_v1_token_usage_users__user_id__summary_get
       parameters:
         - name: user_id
@@ -7649,7 +11810,8 @@ paths:
             title: User Id
         - name: start_date
           in: query
-          description: Start date for token usage data (defaults to 30 days ago).Time
+          description: >-
+            Start date for token usage data (defaults to 30 days ago).Time
             defaults to 00:00:00.
           required: false
           style: form
@@ -7659,12 +11821,14 @@ paths:
               - type: string
                 format: date-time
               - type: 'null'
-            description: Start date for token usage data (defaults to 30 days ago).Time
+            description: >-
+              Start date for token usage data (defaults to 30 days ago).Time
               defaults to 00:00:00.
             title: Start Date
         - name: end_date
           in: query
-          description: End date for token usage data (defaults to current time).Time
+          description: >-
+            End date for token usage data (defaults to current time).Time
             defaults to 00:00:00.
           required: false
           style: form
@@ -7674,7 +11838,8 @@ paths:
               - type: string
                 format: date-time
               - type: 'null'
-            description: End date for token usage data (defaults to current time).Time
+            description: >-
+              End date for token usage data (defaults to current time).Time
               defaults to 00:00:00.
             title: End Date
       responses:
@@ -7683,28 +11848,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserTokenUsageSummaryDetail"
+                $ref: '#/components/schemas/UserTokenUsageSummaryDetail'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/token-usage/users/{user_id}":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/token-usage/users/{user_id}':
     get:
       tags:
         - token-usage
       summary: Get User Model Breakdown
-      description: |-
+      description: >-
         Get model breakdown for a specific user within the specified date range.
+
         If no dates are provided, returns model breakdown for the last 30 days.
-        Note: If no time is provided in datetime parameters, time components default to 00:00:00.
+
+        Note: If no time is provided in datetime parameters, time components
+        default to 00:00:00.
       operationId: get_user_model_breakdown_api_v1_token_usage_users__user_id__get
       parameters:
         - name: user_id
@@ -7718,7 +11890,8 @@ paths:
             title: User Id
         - name: start_date
           in: query
-          description: Start date for token usage data (defaults to 30 days ago).Time
+          description: >-
+            Start date for token usage data (defaults to 30 days ago).Time
             defaults to 00:00:00.
           required: false
           style: form
@@ -7728,12 +11901,14 @@ paths:
               - type: string
                 format: date-time
               - type: 'null'
-            description: Start date for token usage data (defaults to 30 days ago).Time
+            description: >-
+              Start date for token usage data (defaults to 30 days ago).Time
               defaults to 00:00:00.
             title: Start Date
         - name: end_date
           in: query
-          description: End date for token usage data (defaults to current time).Time
+          description: >-
+            End date for token usage data (defaults to current time).Time
             defaults to 00:00:00.
           required: false
           style: form
@@ -7743,7 +11918,8 @@ paths:
               - type: string
                 format: date-time
               - type: 'null'
-            description: End date for token usage data (defaults to current time).Time
+            description: >-
+              End date for token usage data (defaults to current time).Time
               defaults to 00:00:00.
             title: End Date
       responses:
@@ -7752,26 +11928,32 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/TokenUsageSummary"
+                $ref: '#/components/schemas/TokenUsageSummary'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/security-classifications/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /security-classifications/:
     get:
       tags:
         - security-classifications
       summary: List Security Classifications
-      description: |-
-        List all security classifications ordered by security classification level.
+      description: >-
+        List all security classifications ordered by security classification
+        level.
+
         Returns:
             List of security classifications ordered by security classification level.
         Raises:
@@ -7783,19 +11965,23 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SecurityClassificationResponse"
+                $ref: '#/components/schemas/SecurityClassificationResponse'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - security-classifications
@@ -7813,7 +11999,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SecurityClassificationCreatePublic"
+              $ref: '#/components/schemas/SecurityClassificationCreatePublic'
         required: true
       responses:
         '201':
@@ -7821,25 +12007,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SecurityClassificationPublic"
+                $ref: '#/components/schemas/SecurityClassificationPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     patch:
       tags:
         - security-classifications
@@ -7854,12 +12044,13 @@ paths:
             400: If the request is invalid.
             403: If the user doesn't have permission to update the security classification.
             404: If the security classification doesn't exist or belongs to a different tenant.
-      operationId: update_security_classification_levels_api_v1_security_classifications__patch
+      operationId: >-
+        update_security_classification_levels_api_v1_security_classifications__patch
       requestBody:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SecurityClassificationLevelsUpdateRequest"
+              $ref: '#/components/schemas/SecurityClassificationLevelsUpdateRequest'
         required: true
       responses:
         '200':
@@ -7867,38 +12058,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SecurityClassificationsListPublic"
+                $ref: '#/components/schemas/SecurityClassificationsListPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/security-classifications/{id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/security-classifications/{id}/':
     get:
       tags:
         - security-classifications
@@ -7929,31 +12124,35 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SecurityClassificationPublic"
+                $ref: '#/components/schemas/SecurityClassificationPublic'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - security-classifications
@@ -7965,7 +12164,8 @@ paths:
         Raises:
             403: If the user doesn't have permission to delete the security classification.
             404: If the security classification doesn't exist.
-      operationId: delete_security_classification_api_v1_security_classifications__id___delete
+      operationId: >-
+        delete_security_classification_api_v1_security_classifications__id___delete
       parameters:
         - name: id
           in: path
@@ -7984,34 +12184,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     patch:
       tags:
         - security-classifications
       summary: Update Security Classification
-      description: |-
+      description: >-
         Update a single security classification's name and/or description.
 
-        This endpoint allows updating just the name and description of a security classification
+
+        This endpoint allows updating just the name and description of a
+        security classification
+
         without changing its security level.
+
 
         Args:
             id: The ID of the security classification to update
@@ -8024,7 +12232,8 @@ paths:
             400: If the request is invalid or security is disabled. Names must be unique.
             403: If the user doesn't have permission to update the classification
             404: If the security classification doesn't exist
-      operationId: update_security_classification_api_v1_security_classifications__id___patch
+      operationId: >-
+        update_security_classification_api_v1_security_classifications__id___patch
       parameters:
         - name: id
           in: path
@@ -8039,7 +12248,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SecurityClassificationSingleUpdate"
+              $ref: '#/components/schemas/SecurityClassificationSingleUpdate'
         required: true
       responses:
         '200':
@@ -8047,38 +12256,42 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SecurityClassificationPublic"
+                $ref: '#/components/schemas/SecurityClassificationPublic'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/security-classifications/enable/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /security-classifications/enable/:
     post:
       tags:
         - security-classifications
@@ -8095,12 +12308,13 @@ paths:
         Raises:
             400: If the request is invalid.
             403: If the user doesn't have permission to update tenant settings.
-      operationId: toggle_security_classifications_api_v1_security_classifications_enable__post
+      operationId: >-
+        toggle_security_classifications_api_v1_security_classifications_enable__post
       requestBody:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SecurityEnableRequest"
+              $ref: '#/components/schemas/SecurityEnableRequest'
         required: true
       responses:
         '200':
@@ -8108,32 +12322,961 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/SecurityEnableResponse"
+                $ref: '#/components/schemas/SecurityEnableResponse'
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/integrations/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /audit/config:
+    get:
+      tags:
+        - audit
+        - audit
+      summary: Get audit category configuration
+      description: Retrieve all audit category configurations for the current tenant.
+      operationId: get_audit_config_api_v1_audit_config_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditConfigResponse'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    patch:
+      tags:
+        - audit
+        - audit
+      summary: Update audit category configuration
+      description: Update one or more audit category configurations for the current tenant.
+      operationId: update_audit_config_api_v1_audit_config_patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuditConfigUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditConfigResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /audit/config/actions:
+    get:
+      tags:
+        - audit
+        - audit
+      summary: Get per-action audit configuration
+      description: Retrieve all 65 actions with their enabled status for the modal UI.
+      operationId: get_action_config_api_v1_audit_config_actions_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActionConfigResponse'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    patch:
+      tags:
+        - audit
+        - audit
+      summary: Update per-action audit configuration
+      description: Update one or more action-level audit configurations.
+      operationId: update_action_config_api_v1_audit_config_actions_patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActionConfigUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActionConfigResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /audit/access-session/rate-limit:
+    delete:
+      tags:
+        - audit
+        - audit
+      summary: Reset Rate Limit
+      description: >-
+        Admin utility: Reset audit session rate limit for current user.
+
+
+        This endpoint is only available in development/testing environments.
+
+        Use when you get rate limited during testing.
+
+
+        Requires: Authentication (JWT token or API key)
+
+        Requires: Development/testing environment
+
+
+        Note: Permission check intentionally removed to allow clearing rate
+        limit
+
+        even when locked out. User is still authenticated via JWT.
+      operationId: reset_rate_limit_api_v1_audit_access_session_rate_limit_delete
+      responses:
+        '204':
+          description: Successful Response
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /audit/access-session:
+    post:
+      tags:
+        - audit
+        - audit
+      summary: Create Access Session
+      description: >-
+        Create an audit access session with justification.
+
+
+        Stores the access justification securely in Redis (server-side) instead
+        of
+
+        exposing it in URL parameters. Returns an HTTP-only cookie with session
+        ID.
+
+
+        Security Features:
+
+        - Justification never appears in URLs or browser history
+
+        - Session ID stored in HTTP-only cookie (prevents XSS)
+
+        - Automatic expiration after 1 hour
+
+        - Tenant isolation validation
+
+        - Instant revocation capability
+
+
+        Requires: Authentication (JWT token or API key)
+
+        Requires: Admin permissions
+
+
+        Returns: Session creation confirmation with HTTP-only cookie set
+      operationId: create_access_session_api_v1_audit_access_session_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccessJustificationRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessJustificationResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /audit/logs:
+    get:
+      tags:
+        - audit
+        - audit
+      summary: List Audit Logs
+      description: |-
+        List audit logs for the authenticated user's tenant.
+
+        Security:
+        - Requires active audit access session (via HTTP-only cookie)
+        - Session must contain valid justification
+        - Justification stored server-side (Redis) - never in URLs
+
+        Access Control:
+        - Admins only: View all actions in their tenant
+
+        Requires: Authentication (JWT token or API key)
+        Requires: Admin permissions
+        Requires: Active audit access session with justification
+      operationId: list_audit_logs_api_v1_audit_logs_get
+      parameters:
+        - name: actor_id
+          in: query
+          description: Filter by actor
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+                format: uuid
+              - type: 'null'
+            description: Filter by actor
+            title: Actor Id
+        - name: action
+          in: query
+          description: 'Filter by single action type (deprecated, use actions)'
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/ActionType'
+              - type: 'null'
+            description: 'Filter by single action type (deprecated, use actions)'
+            title: Action
+        - name: from_date
+          in: query
+          description: Filter from date
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: 'null'
+            description: Filter from date
+            title: From Date
+        - name: to_date
+          in: query
+          description: Filter to date
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: 'null'
+            description: Filter to date
+            title: To Date
+        - name: search
+          in: query
+          description: Search entity names in log descriptions (min 3 chars)
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+                maxLength: 100
+                minLength: 3
+              - type: 'null'
+            description: Search entity names in log descriptions (min 3 chars)
+            title: Search
+        - name: page
+          in: query
+          description: Page number
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 1
+            description: Page number
+            minimum: 1
+            title: Page
+        - name: page_size
+          in: query
+          description: Page size
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 100
+            description: Page size
+            maximum: 1000
+            minimum: 1
+            title: Page Size
+        - name: actions
+          in: query
+          description: Filter by multiple action types (comma-separated or repeated)
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: array
+                items:
+                  type: string
+              - type: 'null'
+            description: Filter by multiple action types (comma-separated or repeated)
+            title: Actions
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditLogListResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/audit/logs/user/{user_id}':
+    get:
+      tags:
+        - audit
+        - audit
+      summary: Get User Logs
+      description: |-
+        Get all logs where user is actor OR target (GDPR Article 15 export).
+
+        Returns audit logs involving the user in any capacity.
+
+        Requires: Authentication (JWT token or API key via X-API-Key header)
+        Requires: Admin permissions
+        Security: Only returns logs for the authenticated user's tenant
+      operationId: get_user_logs_api_v1_audit_logs_user__user_id__get
+      parameters:
+        - name: user_id
+          in: path
+          description: User ID for GDPR export
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            description: User ID for GDPR export
+            title: User Id
+        - name: from_date
+          in: query
+          description: Filter from date
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: 'null'
+            description: Filter from date
+            title: From Date
+        - name: to_date
+          in: query
+          description: Filter to date
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: 'null'
+            description: Filter to date
+            title: To Date
+        - name: page
+          in: query
+          description: Page number
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 1
+            description: Page number
+            minimum: 1
+            title: Page
+        - name: page_size
+          in: query
+          description: Page size
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 100
+            description: Page size
+            maximum: 1000
+            minimum: 1
+            title: Page Size
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditLogListResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /audit/logs/export:
+    get:
+      tags:
+        - audit
+        - audit
+      summary: Export Audit Logs
+      description: |-
+        Export audit logs to CSV or JSON Lines format.
+
+        Supported formats:
+        - csv: Comma-separated values (default, Excel-compatible)
+        - json: JSON Lines format (one JSON object per line, for large exports)
+
+        Use user_id for GDPR Article 15 data subject access requests.
+
+        Memory Protection:
+        - Default limit: 50,000 records (configurable via max_records parameter)
+        - Response includes X-Records-Truncated header if limit was hit
+        - Response includes X-Total-Records header with total matching count
+
+        Requires: Authentication (JWT token or API key via X-API-Key header)
+        Requires: Admin permissions
+        Security: Only exports logs for the authenticated user's tenant
+      operationId: export_audit_logs_api_v1_audit_logs_export_get
+      parameters:
+        - name: user_id
+          in: query
+          description: User ID for GDPR export
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+                format: uuid
+              - type: 'null'
+            description: User ID for GDPR export
+            title: User Id
+        - name: actor_id
+          in: query
+          description: Filter by actor
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+                format: uuid
+              - type: 'null'
+            description: Filter by actor
+            title: Actor Id
+        - name: action
+          in: query
+          description: Filter by action type
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/ActionType'
+              - type: 'null'
+            description: Filter by action type
+            title: Action
+        - name: from_date
+          in: query
+          description: Filter from date
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: 'null'
+            description: Filter from date
+            title: From Date
+        - name: to_date
+          in: query
+          description: Filter to date
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: 'null'
+            description: Filter to date
+            title: To Date
+        - name: format
+          in: query
+          description: 'Export format: csv or json'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: csv
+            description: 'Export format: csv or json'
+            title: Format
+        - name: max_records
+          in: query
+          description: 'Maximum records to export (default: 50000, max: 100000)'
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: integer
+                maximum: 100000
+                minimum: 1
+              - type: 'null'
+            description: 'Maximum records to export (default: 50000, max: 100000)'
+            title: Max Records
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /audit/logs/export/async:
+    post:
+      tags:
+        - audit
+        - audit
+      summary: Request Async Export
+      description: >-
+        Request async export of audit logs.
+
+
+        Returns immediately with a job_id. Poll /logs/export/{job_id}/status for
+        progress.
+
+        Download via /logs/export/{job_id}/download when complete.
+
+
+        Advantages over sync export:
+
+        - Handles 1M-10M+ records without timeout
+
+        - Progress tracking for long exports
+
+        - Cancellation support
+
+        - Constant memory usage (~50MB)
+
+
+        Limitations:
+
+        - Max 2 concurrent exports per tenant
+
+        - Files auto-deleted after 24 hours
+
+
+        Requires: Authentication (JWT token or API key via X-API-Key header)
+
+        Requires: Admin permissions
+      operationId: request_async_export_api_v1_audit_logs_export_async_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExportJobRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportJobResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/audit/logs/export/{job_id}/status':
+    get:
+      tags:
+        - audit
+        - audit
+      summary: Get Export Status
+      description: |-
+        Get export job status with progress.
+
+        Poll this endpoint to track export progress.
+        When status is 'completed', use the download_url to get the file.
+
+        Requires: Authentication (JWT token or API key via X-API-Key header)
+        Requires: Admin permissions
+      operationId: get_export_status_api_v1_audit_logs_export__job_id__status_get
+      parameters:
+        - name: job_id
+          in: path
+          description: Export job ID
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            description: Export job ID
+            title: Job Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportJobStatusResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/audit/logs/export/{job_id}/download':
+    get:
+      tags:
+        - audit
+        - audit
+      summary: Download Export
+      description: |-
+        Download completed export file.
+
+        Only available when job status is 'completed'.
+        Files are auto-deleted after 24 hours.
+
+        Requires: Authentication (JWT token or API key via X-API-Key header)
+        Requires: Admin permissions
+      operationId: download_export_api_v1_audit_logs_export__job_id__download_get
+      parameters:
+        - name: job_id
+          in: path
+          description: Export job ID
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            description: Export job ID
+            title: Job Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/audit/logs/export/{job_id}/cancel':
+    post:
+      tags:
+        - audit
+        - audit
+      summary: Cancel Export
+      description: |-
+        Cancel an in-progress export.
+
+        Only works for jobs in 'pending' or 'processing' state.
+        The worker will stop processing and clean up the partial file.
+
+        Requires: Authentication (JWT token or API key via X-API-Key header)
+        Requires: Admin permissions
+      operationId: cancel_export_api_v1_audit_logs_export__job_id__cancel_post
+      parameters:
+        - name: job_id
+          in: path
+          description: Export job ID
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            description: Export job ID
+            title: Job Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /audit/retention-policy:
+    get:
+      tags:
+        - audit
+        - audit
+      summary: Get Retention Policy
+      description: |-
+        Get the current retention policy for your tenant.
+
+        Returns audit log retention policy configuration.
+
+        Requires: Authentication (JWT token or API key via X-API-Key header)
+        Requires: Admin permissions
+      operationId: get_retention_policy_api_v1_audit_retention_policy_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionPolicyResponse'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    put:
+      tags:
+        - audit
+        - audit
+      summary: Update Retention Policy
+      description: >-
+        Update the audit log retention policy for your tenant.
+
+
+        Configure audit log retention for compliance and security tracking.
+
+
+        Audit Log Retention:
+
+        - Minimum: 1 day (Recommended: 90+ days for compliance)
+
+        - Maximum: 2555 days (~7 years, Swedish statute of limitations)
+
+        - Default: 365 days (Swedish Arkivlagen)
+
+
+        Note: Conversation retention is configured at the Assistant, App, or
+        Space level.
+
+        Tenant-level conversation retention has been removed to prevent
+        accidental data loss.
+
+
+        The system automatically runs a daily job to delete audit logs older
+        than
+
+        the retention period.
+
+
+        Requires: Authentication (JWT token or API key via X-API-Key header)
+
+        Requires: Admin permissions
+      operationId: update_retention_policy_api_v1_audit_retention_policy_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RetentionPolicyUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionPolicyResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /integrations/:
     get:
       tags:
         - integrations
@@ -8145,14 +13288,18 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/IntegrationList"
+                $ref: '#/components/schemas/IntegrationList'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/integrations/tenant/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /integrations/tenant/:
     get:
       tags:
         - integrations
@@ -8166,7 +13313,7 @@ paths:
           explode: true
           schema:
             anyOf:
-              - "$ref": "#/components/schemas/TenantIntegrationFilter"
+              - $ref: '#/components/schemas/TenantIntegrationFilter'
               - type: 'null'
             title: Filter
       responses:
@@ -8175,25 +13322,30 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/TenantIntegrationList"
+                $ref: '#/components/schemas/TenantIntegrationList'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/integrations/tenant/{integration_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/integrations/tenant/add/{integration_id}/':
     post:
       tags:
         - integrations
       summary: Add Tenant Integration
-      operationId: add_tenant_integration_api_v1_integrations_tenant__integration_id___post
+      operationId: >-
+        add_tenant_integration_api_v1_integrations_tenant_add__integration_id___post
       parameters:
         - name: integration_id
           in: path
@@ -8210,25 +13362,30 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/TenantIntegration"
+                $ref: '#/components/schemas/TenantIntegration'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/integrations/tenant/{tenant_integration_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/integrations/tenant/remove/{tenant_integration_id}/':
     delete:
       tags:
         - integrations
       summary: Remove Tenant Integration
-      operationId: remove_tenant_integration_api_v1_integrations_tenant__tenant_integration_id___delete
+      operationId: >-
+        remove_tenant_integration_api_v1_integrations_tenant_remove__tenant_integration_id___delete
       parameters:
         - name: tenant_integration_id
           in: path
@@ -8247,18 +13404,27 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/integrations/me/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /integrations/me/:
     get:
       tags:
         - integrations
       summary: Get User Integrations
+      description: |-
+        Get user's personal integrations.
+
+        Only returns user_oauth integrations (personal account connections).
+        Tenant app integrations are managed in admin panel and not shown here.
       operationId: get_user_integrations_api_v1_integrations_me__get
       responses:
         '200':
@@ -8266,19 +13432,73 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserIntegrationList"
+                $ref: '#/components/schemas/UserIntegrationList'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/integrations/users/{user_integration_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/integrations/spaces/{space_id}/available/':
+    get:
+      tags:
+        - integrations
+      summary: Get Available Integrations For Space
+      description: >-
+        Get integrations available for a specific space, filtered by space type
+        and auth type.
+
+
+        - Personal spaces: Only user OAuth integrations
+
+        - Shared/Organization spaces: Both tenant app and user OAuth
+        integrations
+      operationId: >-
+        get_available_integrations_for_space_api_v1_integrations_spaces__space_id__available__get
+      parameters:
+        - name: space_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Space Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserIntegrationList'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/integrations/users/{user_integration_id}/':
     delete:
       tags:
         - integrations
       summary: Disconnect User Integration
-      operationId: disconnect_user_integration_api_v1_integrations_users__user_integration_id___delete
+      operationId: >-
+        disconnect_user_integration_api_v1_integrations_users__user_integration_id___delete
       parameters:
         - name: user_integration_id
           in: path
@@ -8297,19 +13517,90 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/integrations/{user_integration_id}/preview/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/integrations/sync-logs/{integration_knowledge_id}/':
+    get:
+      tags:
+        - integrations
+      summary: Get Sync Logs
+      description: Get paginated sync history for an integration knowledge.
+      operationId: >-
+        get_sync_logs_api_v1_integrations_sync_logs__integration_knowledge_id___get
+      parameters:
+        - name: integration_knowledge_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Integration Knowledge Id
+        - name: skip
+          in: query
+          description: Number of items to skip
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 0
+            description: Number of items to skip
+            minimum: 0
+            title: Skip
+        - name: limit
+          in: query
+          description: Number of items per page
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: integer
+            default: 10
+            description: Number of items per page
+            maximum: 100
+            minimum: 1
+            title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSyncLogList'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/integrations/{user_integration_id}/preview/':
     get:
       tags:
         - integrations
       summary: Get Integration Preview
-      operationId: get_integration_preview_api_v1_integrations__user_integration_id__preview__get
+      operationId: >-
+        get_integration_preview_api_v1_integrations__user_integration_id__preview__get
       parameters:
         - name: user_integration_id
           in: path
@@ -8326,20 +13617,137 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/IntegrationPreviewDataList"
+                $ref: '#/components/schemas/IntegrationPreviewDataList'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/integrations/{integration_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/integrations/{user_integration_id}/sharepoint/tree/':
+    get:
+      tags:
+        - integrations
+      summary: Get Sharepoint Folder Tree
+      description: >-
+        Get SharePoint/OneDrive folder tree with hybrid authentication support.
+
+
+        Authentication is determined by space type:
+
+        - Personal space: Uses user OAuth
+
+        - Shared/Org space with tenant app: Uses tenant app (no
+        person-dependency)
+
+        - Shared/Org space without tenant app: Falls back to user OAuth
+
+
+        Provide site_id for SharePoint sites, or drive_id for OneDrive.
+      operationId: >-
+        get_sharepoint_folder_tree_api_v1_integrations__user_integration_id__sharepoint_tree__get
+      parameters:
+        - name: user_integration_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: User Integration Id
+        - name: space_id
+          in: query
+          description: Space ID (for auth routing)
+          required: true
+          style: form
+          explode: true
+          schema:
+            type: string
+            format: uuid
+            description: Space ID (for auth routing)
+            title: Space Id
+        - name: site_id
+          in: query
+          description: SharePoint site ID (required for SharePoint)
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: SharePoint site ID (required for SharePoint)
+            title: Site Id
+        - name: drive_id
+          in: query
+          description: Drive ID (required for OneDrive)
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: Drive ID (required for OneDrive)
+            title: Drive Id
+        - name: folder_id
+          in: query
+          description: Folder ID (null for root)
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: Folder ID (null for root)
+            title: Folder Id
+        - name: folder_path
+          in: query
+          description: Current folder path
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: ''
+            description: Current folder path
+            title: Folder Path
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SharePointTreeResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/integrations/{integration_id}/':
     get:
       tags:
         - integrations
@@ -8361,25 +13769,490 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Integration"
+                $ref: '#/components/schemas/Integration'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/ai-models/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /integrations/sharepoint/webhook/:
+    get:
+      tags:
+        - integrations
+      summary: Sharepoint Webhook Validation
+      operationId: >-
+        sharepoint_webhook_validation_api_v1_integrations_sharepoint_webhook__get
+      parameters:
+        - name: validationToken
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Validationtoken
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - default: []
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    post:
+      tags:
+        - integrations
+      summary: Sharepoint Webhook
+      operationId: sharepoint_webhook_api_v1_integrations_sharepoint_webhook__post
+      parameters:
+        - name: validationToken
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Validationtoken
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - default: []
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/sharepoint/app:
+    get:
+      tags:
+        - admin
+      summary: Get tenant SharePoint app configuration
+      description: >-
+        Retrieve the current SharePoint app configuration for the tenant. Client
+        secret is masked in the response. Requires admin role.
+      operationId: get_sharepoint_app_api_v1_admin_sharepoint_app_get
+      responses:
+        '200':
+          description: >-
+            SharePoint app configuration retrieved (may be null if not
+            configured)
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/TenantSharePointAppPublic'
+                  - type: 'null'
+                title: Response Get Sharepoint App Api V1 Admin Sharepoint App Get
+        '401':
+          description: Authentication required
+        '403':
+          description: Admin permissions required
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    post:
+      tags:
+        - admin
+      summary: Configure tenant SharePoint app
+      description: >-
+        Configure Microsoft Entra ID application credentials for
+        organization-wide SharePoint access. This eliminates person-dependency
+        for shared and organization spaces by using application permissions
+        instead of delegated user permissions. Requires admin role.
+      operationId: configure_sharepoint_app_api_v1_admin_sharepoint_app_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantSharePointAppCreate'
+        required: true
+      responses:
+        '201':
+          description: SharePoint app successfully configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantSharePointAppPublic'
+        '400':
+          description: Invalid credentials or configuration
+        '401':
+          description: Authentication required
+        '403':
+          description: Admin permissions required
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+    delete:
+      tags:
+        - admin
+      summary: Permanently delete SharePoint app
+      description: >-
+        Permanently delete the tenant's SharePoint app configuration and all
+        associated data. WARNING: This action CANNOT be undone. This will
+        cascade delete:
+
+        - All user_integrations using this tenant app (both org and personal)
+
+        - All integration_knowledge (imported SharePoint content)
+
+        - All info_blobs and embeddings (document data and vectors)
+
+        - All sharepoint_subscriptions (webhooks)
+
+        - All oauth_tokens for personal SharePoint integrations
+
+        - All sync_logs
+
+
+        Assistants linked to this knowledge will lose their connections.
+
+        Requires admin role.
+      operationId: delete_sharepoint_app_api_v1_admin_sharepoint_app_delete
+      responses:
+        '200':
+          description: SharePoint app permanently deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: >-
+                  Response Delete Sharepoint App Api V1 Admin Sharepoint App
+                  Delete
+        '401':
+          description: Authentication required
+        '403':
+          description: Admin permissions required
+        '404':
+          description: No SharePoint app configured
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/sharepoint/app/test:
+    post:
+      tags:
+        - admin
+      summary: Test SharePoint app credentials
+      description: >-
+        Test if the provided SharePoint app credentials are valid by attempting
+        to acquire an access token. This does not save the credentials. Requires
+        admin role.
+      operationId: test_sharepoint_app_credentials_api_v1_admin_sharepoint_app_test_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantSharePointAppCreate'
+        required: true
+      responses:
+        '200':
+          description: Test completed (check success field in response)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantAppTestResult'
+        '401':
+          description: Authentication required
+        '403':
+          description: Admin permissions required
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/sharepoint/subscriptions:
+    get:
+      tags:
+        - admin
+      summary: List all SharePoint webhook subscriptions
+      description: >-
+        Get all SharePoint webhook subscriptions for the tenant. Shows status,
+        expiration time, and related integration information. Requires admin
+        role.
+      operationId: list_sharepoint_subscriptions_api_v1_admin_sharepoint_subscriptions_get
+      responses:
+        '200':
+          description: List of subscriptions retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SharePointSubscriptionPublic'
+                title: >-
+                  Response List Sharepoint Subscriptions Api V1 Admin Sharepoint
+                  Subscriptions Get
+        '401':
+          description: Authentication required
+        '403':
+          description: Admin permissions required
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/sharepoint/subscriptions/renew-expired:
+    post:
+      tags:
+        - admin
+      summary: Renew all expired SharePoint subscriptions
+      description: >-
+        Recreate all expired SharePoint webhook subscriptions for the tenant.
+        This is useful after server downtime > 24h when subscriptions have
+        expired. Preserves all integration relationships - assistants continue
+        to work. Requires admin role.
+      operationId: >-
+        renew_expired_subscriptions_api_v1_admin_sharepoint_subscriptions_renew_expired_post
+      responses:
+        '200':
+          description: Renewal operation completed (check result for details)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubscriptionRenewalResult'
+        '401':
+          description: Authentication required
+        '403':
+          description: Admin permissions required
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/admin/sharepoint/subscriptions/{subscription_id}/recreate':
+    post:
+      tags:
+        - admin
+      summary: Recreate a specific SharePoint subscription
+      description: >-
+        Recreate a specific SharePoint webhook subscription. Useful for targeted
+        fixes of expired or problematic subscriptions. Preserves all integration
+        relationships. Requires admin role.
+      operationId: >-
+        recreate_subscription_api_v1_admin_sharepoint_subscriptions__subscription_id__recreate_post
+      parameters:
+        - name: subscription_id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: uuid
+            title: Subscription Id
+      responses:
+        '200':
+          description: Subscription successfully recreated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SharePointSubscriptionPublic'
+        '401':
+          description: Authentication required
+        '403':
+          description: Admin permissions required
+        '404':
+          description: Subscription not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/sharepoint/service-account/auth/start:
+    post:
+      tags:
+        - admin
+      summary: Start service account OAuth flow
+      description: >-
+        Start the OAuth flow for configuring a service account. Returns an
+        authorization URL that the admin should be redirected to. The admin will
+        log in with the service account credentials at Microsoft. Requires admin
+        role.
+      operationId: >-
+        start_service_account_auth_api_v1_admin_sharepoint_service_account_auth_start_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceAccountAuthStart'
+        required: true
+      responses:
+        '200':
+          description: OAuth authorization URL generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceAccountAuthStartResponse'
+        '401':
+          description: Authentication required
+        '403':
+          description: Admin permissions required
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /admin/sharepoint/service-account/auth/callback:
+    post:
+      tags:
+        - admin
+      summary: Complete service account OAuth flow
+      description: >-
+        Complete the OAuth flow by exchanging the authorization code for tokens.
+        This will configure the service account for the tenant's SharePoint
+        access. Requires admin role.
+      operationId: >-
+        service_account_auth_callback_api_v1_admin_sharepoint_service_account_auth_callback_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceAccountAuthCallback'
+        required: true
+      responses:
+        '201':
+          description: Service account successfully configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantSharePointAppPublic'
+        '400':
+          description: Invalid state or auth code
+        '401':
+          description: Authentication required
+        '403':
+          description: Admin permissions required
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - OAuth2PasswordBearer: []
+        - APIKeyHeader: []
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /ai-models/:
     get:
       tags:
         - ai-models
       summary: Get all AI models
-      description: Get all completion, embedding, and transcription models.
+      description: 'Get all completion, embedding, and transcription models.'
       operationId: get_models_api_v1_ai_models__get
       parameters:
         - name: space_id
@@ -8401,32 +14274,36 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/ModelsPresentation"
+                $ref: '#/components/schemas/ModelsPresentation'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
         '500':
           description: Internal Server Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/integrations/auth/{tenant_integration_id}/url/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/integrations/auth/{tenant_integration_id}/url/':
     get:
       tags:
         - integrations
@@ -8458,20 +14335,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AuthUrlPublic"
+                $ref: '#/components/schemas/AuthUrlPublic'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/integrations/auth/callback/token/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /integrations/auth/callback/token/:
     post:
       tags:
         - integrations
@@ -8481,7 +14362,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/AuthCallbackParams"
+              $ref: '#/components/schemas/AuthCallbackParams'
         required: true
       responses:
         '200':
@@ -8489,25 +14370,188 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/UserIntegration"
+                $ref: '#/components/schemas/UserIntegration'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/api-docs":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /auth/federation-status:
+    get:
+      tags:
+        - authentication
+        - authentication
+      summary: Check federation configuration status
+      description: >-
+        Returns federation availability status for the system. Used by login
+        page to determine which authentication method to show. No authentication
+        required (public endpoint).
+      operationId: get_federation_status_api_v1_auth_federation_status_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FederationStatusResponse'
+      security:
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /auth/tenants:
+    get:
+      tags:
+        - authentication
+        - authentication
+      summary: List tenants for selector
+      description: >-
+        Public endpoint returning all active tenants for the tenant selector
+        grid. Only returns tenants with slugs configured for federation. No
+        authentication required.
+      operationId: list_tenants_api_v1_auth_tenants_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantListResponse'
+      security:
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /auth/initiate:
+    get:
+      tags:
+        - authentication
+        - authentication
+      summary: Initiate OIDC authentication
+      description: >-
+        Get authorization URL for tenant's identity provider. No authentication
+        required. Returns URL to redirect user to IdP login page.
+      operationId: initiate_auth_api_v1_auth_initiate_get
+      parameters:
+        - name: tenant
+          in: query
+          description: 'Tenant slug (required for multi-tenant, optional for single-tenant)'
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: >-
+              Tenant slug (required for multi-tenant, optional for
+              single-tenant)
+            title: Tenant
+        - name: state
+          in: query
+          description: Optional frontend-generated CSRF state
+          required: false
+          style: form
+          explode: true
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: Optional frontend-generated CSRF state
+            title: State
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InitiateAuthResponse'
+        '403':
+          description: Tenant is not active
+        '404':
+          description: Tenant not found or not configured
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '500':
+          description: Federation or redirect configuration missing
+      security:
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /auth/callback:
+    post:
+      tags:
+        - authentication
+        - authentication
+      summary: OIDC callback handler
+      description: >-
+        Handle OIDC callback, validate token, lookup user. No authentication
+        required (public endpoint). Returns JWT token for authenticated user.
+      operationId: auth_callback_api_v1_auth_callback_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CallbackRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '400':
+          description: Invalid or expired state
+        '401':
+          description: Token validation failed
+        '403':
+          description: 'Domain not allowed, inactive tenant, or user missing'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /api-docs:
     get:
       tags:
         - Documentation
       summary: Get OpenAPI specification
-      description: Returns the complete OpenAPI 3.0 specification for this API. Compatible
+      description: >-
+        Returns the complete OpenAPI 3.0 specification for this API. Compatible
         with WSO2 API Manager.
       operationId: get_api_documentation_api_v1_api_docs_get
       responses:
@@ -8520,7 +14564,11 @@ paths:
         - default: []
       x-auth-type: None
       x-throttling-tier: Unlimited
-  "/roles/permissions/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /roles/permissions/:
     get:
       tags:
         - roles
@@ -8534,21 +14582,25 @@ paths:
               schema:
                 type: array
                 items:
-                  "$ref": "#/components/schemas/PermissionPublic"
+                  $ref: '#/components/schemas/PermissionPublic'
                 title: Response Get Permissions Api V1 Roles Permissions  Get
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/roles/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /roles/:
     get:
       tags:
         - roles
@@ -8560,13 +14612,17 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/RolesPaginatedResponse"
+                $ref: '#/components/schemas/RolesPaginatedResponse'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - roles
@@ -8576,7 +14632,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/RoleCreateRequest"
+              $ref: '#/components/schemas/RoleCreateRequest'
         required: true
       responses:
         '200':
@@ -8584,20 +14640,24 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/RolePublic"
+                $ref: '#/components/schemas/RolePublic'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/roles/{role_id}/":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  '/roles/{role_id}/':
     get:
       tags:
         - roles
@@ -8619,25 +14679,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/RolePublic"
+                $ref: '#/components/schemas/RolePublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     post:
       tags:
         - roles
@@ -8657,7 +14721,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/RoleUpdateRequest"
+              $ref: '#/components/schemas/RoleUpdateRequest'
         required: true
       responses:
         '200':
@@ -8665,25 +14729,29 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/RolePublic"
+                $ref: '#/components/schemas/RolePublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
     delete:
       tags:
         - roles
@@ -8705,29 +14773,33 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/RolePublic"
+                $ref: '#/components/schemas/RolePublic'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/GeneralError"
+                $ref: '#/components/schemas/GeneralError'
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
         - OAuth2PasswordBearer: []
         - APIKeyHeader: []
         - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/healthz":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /api/healthz:
     get:
       summary: Get Healthz
-      operationId: get_healthz_healthz_get
+      operationId: get_healthz_api_healthz_get
       responses:
         '200':
           description: Successful Response
@@ -8736,9 +14808,58 @@ paths:
               schema: {}
       security:
         - default: []
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /api/healthz/crawler:
+    get:
+      summary: Crawler Health
+      description: >-
+        Detailed crawler diagnostics. NOT for K8s probes.
+
+
+        Public endpoint - no auth required. Shows only job counts and tenant
+        IDs.
+
+
+        Args:
+            include_all: If True, return all tenant queue lengths instead of top-10.
+      operationId: crawler_health_api_healthz_crawler_get
+      parameters:
+        - name: include_all
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: boolean
+            default: false
+            title: Include All
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrawlerHealthResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+        - default: []
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-  "/version":
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
+  /version:
     get:
       summary: Get Version
       operationId: get_version_version_get
@@ -8750,12 +14871,50 @@ paths:
               schema: {}
       security:
         - OAuth2PasswordBearer: []
-        - APIKeyHeader: []
         - default: []
-      x-auth-type: Application & Application User
+      x-auth-type: None
       x-throttling-tier: Unlimited
+      x-wso2-application-security:
+        security-types:
+          - oauth2
+        optional: false
 components:
   schemas:
+    ARQHealth:
+      type: object
+      description: Parsed ARQ health metrics (clean view).
+      properties:
+        heartbeat_ttl_seconds:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Heartbeat Ttl Seconds
+        age_seconds:
+          anyOf:
+            - type: number
+            - type: 'null'
+          title: Age Seconds
+        j_complete:
+          type: integer
+          default: 0
+          title: J Complete
+        j_failed:
+          type: integer
+          default: 0
+          title: J Failed
+        j_retried:
+          type: integer
+          default: 0
+          title: J Retried
+        j_ongoing:
+          type: integer
+          default: 0
+          title: J Ongoing
+        queued:
+          type: integer
+          default: 0
+          title: Queued
+      title: ARQHealth
     AcceptedFileType:
       type: object
       properties:
@@ -8769,6 +14928,42 @@ components:
         - mimetype
         - size_limit
       title: AcceptedFileType
+    AccessJustificationRequest:
+      type: object
+      description: Schema for creating audit access session with justification.
+      properties:
+        category:
+          type: string
+          description: Justification category
+          maxLength: 100
+          minLength: 1
+          title: Category
+        description:
+          type: string
+          description: Detailed access reason
+          maxLength: 500
+          minLength: 10
+          title: Description
+      required:
+        - category
+        - description
+      title: AccessJustificationRequest
+    AccessJustificationResponse:
+      type: object
+      description: Schema for access session creation response.
+      properties:
+        status:
+          type: string
+          default: session_created
+          description: Status of session creation
+          title: Status
+        message:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Additional message if needed
+          title: Message
+      title: AccessJustificationResponse
     AccessToken:
       type: object
       properties:
@@ -8782,6 +14977,205 @@ components:
         - access_token
         - token_type
       title: AccessToken
+    ActionConfig:
+      type: object
+      description: Configuration for a single action type with metadata for UI display.
+      example:
+        action: user_created
+        category: admin_actions
+        description_sv: Loggar när en ny användare skapas
+        enabled: true
+        name_sv: Användare skapad
+      properties:
+        action:
+          type: string
+          description: 'Action type value (e.g., ''user_created'')'
+          title: Action
+        enabled:
+          type: boolean
+          description: Whether this action is currently enabled
+          title: Enabled
+        category:
+          type: string
+          description: Category this action belongs to
+          title: Category
+        name_sv:
+          type: string
+          description: Swedish display name
+          title: Name Sv
+        description_sv:
+          type: string
+          description: Swedish description
+          title: Description Sv
+      required:
+        - action
+        - category
+        - description_sv
+        - enabled
+        - name_sv
+      title: ActionConfig
+    ActionConfigResponse:
+      type: object
+      description: |-
+        Response model for GET /api/v1/audit/config/actions.
+        Contains all 65 actions with their configuration and metadata.
+      example:
+        actions:
+          - action: user_created
+            category: admin_actions
+            description_sv: Loggar när en ny användare skapas
+            enabled: true
+            name_sv: Användare skapad
+          - action: user_deleted
+            category: admin_actions
+            description_sv: Loggar när en användare tas bort
+            enabled: false
+            name_sv: Användare raderad
+      properties:
+        actions:
+          type: array
+          description: List of all actions with configuration and Swedish metadata
+          items:
+            $ref: '#/components/schemas/ActionConfig'
+          title: Actions
+      required:
+        - actions
+      title: ActionConfigResponse
+    ActionConfigUpdateRequest:
+      type: object
+      description: |-
+        Request model for PATCH /api/v1/audit/config/actions.
+        Allows bulk updates of multiple action overrides.
+      example:
+        updates:
+          - action: user_created
+            enabled: false
+          - action: user_deleted
+            enabled: false
+      properties:
+        updates:
+          type: array
+          description: List of action configuration updates
+          items:
+            $ref: '#/components/schemas/ActionUpdate'
+          maxItems: 65
+          minItems: 1
+          title: Updates
+      required:
+        - updates
+      title: ActionConfigUpdateRequest
+    ActionType:
+      type: string
+      description: Standardized vocabulary of auditable actions
+      enum:
+        - user_created
+        - user_deleted
+        - user_updated
+        - role_created
+        - role_modified
+        - role_deleted
+        - permission_changed
+        - tenant_settings_updated
+        - credentials_updated
+        - federation_updated
+        - api_key_generated
+        - module_added
+        - module_added_to_tenant
+        - assistant_created
+        - assistant_deleted
+        - assistant_updated
+        - assistant_transferred
+        - assistant_published
+        - space_created
+        - space_updated
+        - space_deleted
+        - space_member_added
+        - space_member_removed
+        - app_created
+        - app_deleted
+        - app_updated
+        - app_executed
+        - app_published
+        - app_run_deleted
+        - session_started
+        - session_ended
+        - file_uploaded
+        - file_deleted
+        - website_created
+        - website_updated
+        - website_deleted
+        - website_crawled
+        - website_transferred
+        - group_chat_created
+        - collection_created
+        - collection_updated
+        - collection_deleted
+        - integration_added
+        - integration_removed
+        - integration_connected
+        - integration_disconnected
+        - integration_knowledge_created
+        - integration_knowledge_deleted
+        - integration_knowledge_synced
+        - completion_model_updated
+        - embedding_model_updated
+        - transcription_model_updated
+        - template_created
+        - template_updated
+        - template_deleted
+        - security_classification_created
+        - security_classification_updated
+        - security_classification_deleted
+        - security_classification_levels_updated
+        - security_classification_enabled
+        - security_classification_disabled
+        - retention_policy_applied
+        - encryption_key_rotated
+        - system_maintenance
+        - audit_session_created
+        - audit_log_viewed
+        - audit_log_exported
+      title: ActionType
+    ActionUpdate:
+      type: object
+      description: Represents an action-level configuration change request.
+      example:
+        action: user_created
+        enabled: false
+      properties:
+        action:
+          type: string
+          description: Action name to update
+          title: Action
+        enabled:
+          type: boolean
+          description: New enabled state
+          title: Enabled
+      required:
+        - action
+        - enabled
+      title: ActionUpdate
+    ActorType:
+      type: string
+      description: Categorize who performed the action
+      enum:
+        - user
+        - system
+        - api_key
+      title: ActorType
+    AddSpaceGroupMemberRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        role:
+          $ref: '#/components/schemas/SpaceRoleValue'
+      required:
+        - id
+        - role
+      title: AddSpaceGroupMemberRequest
     AddSpaceMemberRequest:
       type: object
       properties:
@@ -8790,7 +15184,7 @@ components:
           format: uuid
           title: Id
         role:
-          "$ref": "#/components/schemas/SpaceRoleValue"
+          $ref: '#/components/schemas/SpaceRoleValue'
       required:
         - id
         - role
@@ -8799,7 +15193,7 @@ components:
       type: object
       properties:
         type:
-          "$ref": "#/components/schemas/WizardType"
+          $ref: '#/components/schemas/WizardType'
         value:
           type: array
           items:
@@ -8931,7 +15325,7 @@ components:
           title: Name
         completion_model:
           anyOf:
-            - "$ref": "#/components/schemas/CompletionModelPublicAppTemplate"
+            - $ref: '#/components/schemas/CompletionModelPublicAppTemplate'
             - type: 'null'
         completion_model_kwargs:
           type: object
@@ -8939,7 +15333,7 @@ components:
           title: Completion Model Kwargs
         prompt:
           anyOf:
-            - "$ref": "#/components/schemas/PromptPublicAppTemplate"
+            - $ref: '#/components/schemas/PromptPublicAppTemplate'
             - type: 'null'
         input_description:
           anyOf:
@@ -8964,7 +15358,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         created_at:
           anyOf:
@@ -8993,37 +15387,47 @@ components:
         input_fields:
           type: array
           items:
-            "$ref": "#/components/schemas/InputFieldPublic"
+            $ref: '#/components/schemas/InputFieldPublic'
           title: Input Fields
         attachments:
           type: array
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Attachments
         prompt:
           anyOf:
-            - "$ref": "#/components/schemas/PromptPublic"
+            - $ref: '#/components/schemas/PromptPublic'
             - type: 'null'
         completion_model:
-          "$ref": "#/components/schemas/CompletionModelSparse"
+          anyOf:
+            - $ref: '#/components/schemas/CompletionModelSparse'
+            - type: 'null'
         completion_model_kwargs:
-          "$ref": "#/components/schemas/ModelKwargs"
+          $ref: '#/components/schemas/ModelKwargs'
         allowed_attachments:
-          "$ref": "#/components/schemas/FileRestrictions"
+          $ref: '#/components/schemas/FileRestrictions'
         published:
           type: boolean
           title: Published
         transcription_model:
-          "$ref": "#/components/schemas/TranscriptionModelPublic"
+          anyOf:
+            - $ref: '#/components/schemas/TranscriptionModelPublic'
+            - type: 'null'
         data_retention_days:
           anyOf:
             - type: integer
             - type: 'null'
           title: Data Retention Days
+        icon_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Icon ID referencing an uploaded icon
+          title: Icon Id
       required:
         - allowed_attachments
         - attachments
-        - completion_model
         - completion_model_kwargs
         - description
         - id
@@ -9031,7 +15435,6 @@ components:
         - name
         - prompt
         - published
-        - transcription_model
       title: AppPublic
     AppRunInput:
       type: object
@@ -9039,7 +15442,7 @@ components:
         files:
           type: array
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Files
         text:
           anyOf:
@@ -9070,9 +15473,9 @@ components:
           format: uuid
           title: Id
         input:
-          "$ref": "#/components/schemas/AppRunInput"
+          $ref: '#/components/schemas/AppRunInput'
         status:
-          "$ref": "#/components/schemas/Status"
+          $ref: '#/components/schemas/Status'
         finished_at:
           anyOf:
             - type: string
@@ -9080,7 +15483,7 @@ components:
             - type: 'null'
           title: Finished At
         user:
-          "$ref": "#/components/schemas/UserSparse"
+          $ref: '#/components/schemas/UserSparse'
         output:
           anyOf:
             - type: string
@@ -9114,9 +15517,9 @@ components:
           format: uuid
           title: Id
         input:
-          "$ref": "#/components/schemas/AppRunInput"
+          $ref: '#/components/schemas/AppRunInput'
         status:
-          "$ref": "#/components/schemas/Status"
+          $ref: '#/components/schemas/Status'
         finished_at:
           anyOf:
             - type: string
@@ -9124,7 +15527,7 @@ components:
             - type: 'null'
           title: Finished At
         user:
-          "$ref": "#/components/schemas/UserSparse"
+          $ref: '#/components/schemas/UserSparse'
       required:
         - finished_at
         - id
@@ -9155,7 +15558,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         name:
           type: string
@@ -9172,19 +15575,267 @@ components:
           type: string
           format: uuid
           title: User Id
+        icon_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Icon ID referencing an uploaded icon
+          title: Icon Id
       required:
         - id
         - name
         - published
         - user_id
       title: AppSparse
+    AppTemplateAdminCreate:
+      type: object
+      description: Admin template creation request.
+      properties:
+        name:
+          type: string
+          title: Name
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Description
+        category:
+          type: string
+          title: Category
+        prompt:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Prompt
+        completion_model_kwargs:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          title: Completion Model Kwargs
+        wizard:
+          anyOf:
+            - $ref: '#/components/schemas/AppTemplateWizard'
+            - type: 'null'
+        input_type:
+          type: string
+          title: Input Type
+        input_description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Input Description
+        icon_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Icon Name
+      required:
+        - category
+        - input_type
+        - name
+      title: AppTemplateAdminCreate
+    AppTemplateAdminListPublic:
+      type: object
+      description: Admin list response.
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppTemplateAdminPublic'
+          title: Items
+        count:
+          type: integer
+          readOnly: true
+          title: Count
+      required:
+        - count
+        - items
+      title: AppTemplateAdminListPublic
+    AppTemplateAdminPublic:
+      type: object
+      description: Admin view of template with tenant fields.
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        description:
+          type: string
+          title: Description
+        category:
+          type: string
+          title: Category
+        prompt_text:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Prompt Text
+        completion_model_kwargs:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          title: Completion Model Kwargs
+        completion_model_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Completion Model Id
+        completion_model_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Completion Model Name
+        wizard:
+          anyOf:
+            - $ref: '#/components/schemas/AppTemplateWizard'
+            - type: 'null'
+        input_type:
+          type: string
+          title: Input Type
+        input_description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Input Description
+        organization:
+          type: string
+          title: Organization
+        tenant_id:
+          type: string
+          format: uuid
+          title: Tenant Id
+        deleted_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Deleted At
+        deleted_by_user_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Deleted By User Id
+        restored_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Restored At
+        restored_by_user_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Restored By User Id
+        original_snapshot:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          title: Original Snapshot
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+        usage_count:
+          type: integer
+          default: 0
+          title: Usage Count
+        is_default:
+          type: boolean
+          default: false
+          title: Is Default
+        icon_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Icon Name
+      required:
+        - category
+        - created_at
+        - description
+        - id
+        - input_type
+        - name
+        - organization
+        - tenant_id
+        - updated_at
+      title: AppTemplateAdminPublic
+    AppTemplateAdminUpdate:
+      type: object
+      description: Admin template update request (PATCH semantics).
+      properties:
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Name
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Description
+        category:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Category
+        prompt:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Prompt
+        completion_model_kwargs:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          title: Completion Model Kwargs
+        completion_model_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Completion Model Id
+        wizard:
+          anyOf:
+            - $ref: '#/components/schemas/AppTemplateWizard'
+            - type: 'null'
+        input_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Input Type
+        input_description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Input Description
+        icon_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Icon Name
+      title: AppTemplateAdminUpdate
     AppTemplateListPublic:
       type: object
       properties:
         items:
           type: array
           items:
-            "$ref": "#/components/schemas/AppTemplatePublic"
+            $ref: '#/components/schemas/AppTemplatePublic'
           title: Items
         count:
           type: integer
@@ -9231,15 +15882,24 @@ components:
           type: string
           title: Category
         app:
-          "$ref": "#/components/schemas/AppInTemplatePublic"
+          $ref: '#/components/schemas/AppInTemplatePublic'
         type:
           type: string
           const: app
           title: Type
         wizard:
-          "$ref": "#/components/schemas/AppTemplateWizard"
+          $ref: '#/components/schemas/AppTemplateWizard'
         organization:
-          "$ref": "#/components/schemas/AppTemplateOrganization"
+          $ref: '#/components/schemas/AppTemplateOrganization'
+        is_default:
+          type: boolean
+          default: false
+          title: Is Default
+        icon_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Icon Name
       required:
         - app
         - category
@@ -9252,16 +15912,26 @@ components:
         - updated_at
         - wizard
       title: AppTemplatePublic
+    AppTemplateToggleDefaultRequest:
+      type: object
+      description: Request to toggle template as default/featured.
+      properties:
+        is_default:
+          type: boolean
+          title: Is Default
+      required:
+        - is_default
+      title: AppTemplateToggleDefaultRequest
     AppTemplateWizard:
       type: object
       properties:
         attachments:
           anyOf:
-            - "$ref": "#/components/schemas/TemplateWizard"
+            - $ref: '#/components/schemas/TemplateWizard'
             - type: 'null'
         collections:
           anyOf:
-            - "$ref": "#/components/schemas/TemplateWizard"
+            - $ref: '#/components/schemas/TemplateWizard'
             - type: 'null'
       required:
         - attachments
@@ -9284,49 +15954,56 @@ components:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/InputField"
+                $ref: '#/components/schemas/InputField'
             - type: 'null'
           title: Input Fields
         attachments:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/ModelId"
+                $ref: '#/components/schemas/ModelId'
             - type: 'null'
           title: Attachments
         prompt:
           anyOf:
-            - "$ref": "#/components/schemas/PromptCreate"
+            - $ref: '#/components/schemas/PromptCreate'
             - type: 'null'
         completion_model:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
         completion_model_kwargs:
           anyOf:
-            - "$ref": "#/components/schemas/ModelKwargs"
+            - $ref: '#/components/schemas/ModelKwargs'
             - type: 'null'
         transcription_model:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
         data_retention_days:
           anyOf:
             - type: integer
             - type: 'null'
           title: Data Retention Days
+        icon_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Icon ID referencing an uploaded icon. Set to null to remove.
+          title: Icon Id
       title: AppUpdateRequest
     Applications:
       type: object
       properties:
         assistants:
-          "$ref": "#/components/schemas/PaginatedPermissions_AssistantSparse_"
+          $ref: '#/components/schemas/PaginatedPermissions_AssistantSparse_'
         group_chats:
-          "$ref": "#/components/schemas/PaginatedPermissions_GroupChatSparse_"
+          $ref: '#/components/schemas/PaginatedPermissions_GroupChatSparse_'
         services:
-          "$ref": "#/components/schemas/PaginatedPermissions_ServiceSparse_"
+          $ref: '#/components/schemas/PaginatedPermissions_ServiceSparse_'
         apps:
-          "$ref": "#/components/schemas/PaginatedPermissions_AppSparse_"
+          $ref: '#/components/schemas/PaginatedPermissions_AppSparse_'
       required:
         - apps
         - assistants
@@ -9368,8 +16045,9 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ModelId"
-          maxItems: 1
+            type: string
+            format: uuid
+          maxItems: 20
           title: Files
         stream:
           type: boolean
@@ -9377,7 +16055,7 @@ components:
           title: Stream
         tools:
           anyOf:
-            - "$ref": "#/components/schemas/UseTools"
+            - $ref: '#/components/schemas/UseTools'
             - type: 'null'
       required:
         - question
@@ -9398,28 +16076,28 @@ components:
         files:
           type: array
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Files
         generated_files:
           type: array
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Generated Files
         references:
           type: array
           items:
-            "$ref": "#/components/schemas/InfoBlobAskAssistantPublic"
+            $ref: '#/components/schemas/InfoBlobAskAssistantPublic'
           title: References
         tools:
-          "$ref": "#/components/schemas/UseTools"
+          $ref: '#/components/schemas/UseTools'
         web_search_references:
           type: array
           items:
-            "$ref": "#/components/schemas/WebSearchResultPublic"
+            $ref: '#/components/schemas/WebSearchResultPublic'
           title: Web Search References
         model:
           anyOf:
-            - "$ref": "#/components/schemas/CompletionModelPublic"
+            - $ref: '#/components/schemas/CompletionModelPublic'
             - type: 'null'
       required:
         - answer
@@ -9439,7 +16117,7 @@ components:
           title: Name
         completion_model_kwargs:
           anyOf:
-            - "$ref": "#/components/schemas/ModelKwargs"
+            - $ref: '#/components/schemas/ModelKwargs'
             - type: 'null'
           deprecated: true
           description: This field is deprecated and will be ignored
@@ -9456,7 +16134,7 @@ components:
           title: Space Id
         prompt:
           anyOf:
-            - "$ref": "#/components/schemas/PromptCreate"
+            - $ref: '#/components/schemas/PromptCreate'
             - type: 'null'
           deprecated: true
           description: This field is deprecated and will be ignored
@@ -9466,7 +16144,7 @@ components:
           deprecated: true
           description: This field is deprecated and will be ignored
           items:
-            "$ref": "#/components/schemas/ModelId"
+            $ref: '#/components/schemas/ModelId'
           title: Groups
         websites:
           type: array
@@ -9474,7 +16152,7 @@ components:
           deprecated: true
           description: This field is deprecated and will be ignored
           items:
-            "$ref": "#/components/schemas/ModelId"
+            $ref: '#/components/schemas/ModelId'
           title: Websites
         integration_knowledge_list:
           type: array
@@ -9482,17 +16160,17 @@ components:
           deprecated: true
           description: This field is deprecated and will be ignored
           items:
-            "$ref": "#/components/schemas/ModelId"
+            $ref: '#/components/schemas/ModelId'
           title: Integration Knowledge List
         guardrail:
           anyOf:
-            - "$ref": "#/components/schemas/AssistantGuard"
+            - $ref: '#/components/schemas/AssistantGuard'
             - type: 'null'
           deprecated: true
           description: This field is deprecated and will be ignored
         completion_model:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
           deprecated: true
           description: This field is deprecated and will be ignored
@@ -9524,7 +16202,7 @@ components:
           title: Name
         completion_model:
           anyOf:
-            - "$ref": "#/components/schemas/CompletionModelPublicAssistantTemplate"
+            - $ref: '#/components/schemas/CompletionModelPublicAssistantTemplate'
             - type: 'null'
         completion_model_kwargs:
           type: object
@@ -9532,7 +16210,7 @@ components:
           title: Completion Model Kwargs
         prompt:
           anyOf:
-            - "$ref": "#/components/schemas/PromptPublicAssistantTemplate"
+            - $ref: '#/components/schemas/PromptPublicAssistantTemplate'
             - type: 'null'
       required:
         - completion_model
@@ -9561,7 +16239,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         created_at:
           anyOf:
@@ -9584,63 +16262,79 @@ components:
           title: Name
         prompt:
           anyOf:
-            - "$ref": "#/components/schemas/PromptPublic"
+            - $ref: '#/components/schemas/PromptPublic'
             - type: 'null'
         space_id:
           type: string
           format: uuid
           title: Space Id
         completion_model_kwargs:
-          "$ref": "#/components/schemas/ModelKwargs"
+          $ref: '#/components/schemas/ModelKwargs'
         logging_enabled:
           type: boolean
           title: Logging Enabled
         attachments:
           type: array
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Attachments
         allowed_attachments:
-          "$ref": "#/components/schemas/FileRestrictions"
+          $ref: '#/components/schemas/FileRestrictions'
         groups:
           type: array
           items:
-            "$ref": "#/components/schemas/CollectionPublic"
+            $ref: '#/components/schemas/CollectionPublic'
           title: Groups
         websites:
           type: array
           items:
-            "$ref": "#/components/schemas/WebsitePublic"
+            $ref: '#/components/schemas/WebsitePublic'
           title: Websites
         integration_knowledge_list:
           type: array
           items:
-            "$ref": "#/components/schemas/IntegrationKnowledgePublic"
+            $ref: '#/components/schemas/IntegrationKnowledgePublic'
           title: Integration Knowledge List
         completion_model:
-          "$ref": "#/components/schemas/CompletionModelSparse"
+          anyOf:
+            - $ref: '#/components/schemas/CompletionModelSparse'
+            - type: 'null'
         published:
           type: boolean
           default: false
           title: Published
         user:
-          "$ref": "#/components/schemas/UserSparse"
+          $ref: '#/components/schemas/UserSparse'
         tools:
-          "$ref": "#/components/schemas/UseTools"
+          $ref: '#/components/schemas/UseTools'
         type:
-          "$ref": "#/components/schemas/AssistantType"
+          $ref: '#/components/schemas/AssistantType'
+        model_info:
+          anyOf:
+            - $ref: '#/components/schemas/ModelInfo'
+            - type: 'null'
         description:
           anyOf:
             - type: string
             - type: 'null'
-          description: A description of the assitant that will be used as default
+          description: >-
+            A description of the assitant that will be used as default
             description in GroupChatAssistantPublic
           example: This is a helpful AI assistant
           title: Description
+        icon_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Icon ID referencing an uploaded icon
+          title: Icon Id
         insight_enabled:
           type: boolean
-          description: Whether insights are enabled for this assistant. If enabled,
-            users with appropriate permissions can see all sessions for this assistant.
+          description: >-
+            Whether insights are enabled for this assistant. If enabled, users
+            with appropriate permissions can see all sessions for this
+            assistant.
           title: Insight Enabled
         data_retention_days:
           anyOf:
@@ -9658,7 +16352,6 @@ components:
       required:
         - allowed_attachments
         - attachments
-        - completion_model
         - completion_model_kwargs
         - groups
         - id
@@ -9695,7 +16388,7 @@ components:
           type: string
           title: Name
         completion_model_kwargs:
-          "$ref": "#/components/schemas/ModelKwargs"
+          $ref: '#/components/schemas/ModelKwargs'
         logging_enabled:
           type: boolean
           default: false
@@ -9704,7 +16397,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         user_id:
           type: string
@@ -9727,20 +16420,260 @@ components:
           description: Metadata for the assistant
           title: Metadata Json
         type:
-          "$ref": "#/components/schemas/AssistantType"
+          $ref: '#/components/schemas/AssistantType'
+        icon_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Icon ID referencing an uploaded icon
+          title: Icon Id
+        completion_model_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: 'ID of the completion model, or None if not configured'
+          title: Completion Model Id
       required:
         - id
         - name
         - type
         - user_id
       title: AssistantSparse
+    AssistantTemplateAdminCreate:
+      type: object
+      description: Admin template creation request.
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          title: Name
+        description:
+          anyOf:
+            - type: string
+              maxLength: 2000
+            - type: 'null'
+          title: Description
+        category:
+          type: string
+          maxLength: 100
+          minLength: 1
+          title: Category
+        prompt:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Prompt
+        completion_model_kwargs:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          title: Completion Model Kwargs
+        wizard:
+          anyOf:
+            - $ref: '#/components/schemas/AssistantTemplateWizard'
+            - type: 'null'
+        icon_name:
+          anyOf:
+            - type: string
+              maxLength: 100
+            - type: 'null'
+          title: Icon Name
+      required:
+        - category
+        - name
+      title: AssistantTemplateAdminCreate
+    AssistantTemplateAdminListPublic:
+      type: object
+      description: Admin list response.
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssistantTemplateAdminPublic'
+          title: Items
+        count:
+          type: integer
+          readOnly: true
+          title: Count
+      required:
+        - count
+        - items
+      title: AssistantTemplateAdminListPublic
+    AssistantTemplateAdminPublic:
+      type: object
+      description: Admin view of template with tenant fields.
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        description:
+          type: string
+          title: Description
+        category:
+          type: string
+          title: Category
+        prompt_text:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Prompt Text
+        completion_model_kwargs:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          title: Completion Model Kwargs
+        completion_model_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Completion Model Id
+        completion_model_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Completion Model Name
+        wizard:
+          anyOf:
+            - $ref: '#/components/schemas/AssistantTemplateWizard'
+            - type: 'null'
+        organization:
+          type: string
+          title: Organization
+        tenant_id:
+          type: string
+          format: uuid
+          title: Tenant Id
+        deleted_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Deleted At
+        deleted_by_user_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Deleted By User Id
+        restored_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Restored At
+        restored_by_user_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Restored By User Id
+        original_snapshot:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          title: Original Snapshot
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+        usage_count:
+          type: integer
+          default: 0
+          title: Usage Count
+        is_default:
+          type: boolean
+          default: false
+          title: Is Default
+        icon_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Icon Name
+      required:
+        - category
+        - created_at
+        - description
+        - id
+        - name
+        - organization
+        - tenant_id
+        - updated_at
+      title: AssistantTemplateAdminPublic
+    AssistantTemplateAdminUpdate:
+      type: object
+      description: Admin template update request (PATCH semantics).
+      properties:
+        name:
+          anyOf:
+            - type: string
+              maxLength: 255
+              minLength: 1
+            - type: 'null'
+          title: Name
+        description:
+          anyOf:
+            - type: string
+              maxLength: 2000
+              minLength: 1
+            - type: 'null'
+          title: Description
+        category:
+          anyOf:
+            - type: string
+              maxLength: 100
+              minLength: 1
+            - type: 'null'
+          title: Category
+        prompt:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Prompt
+        completion_model_kwargs:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          title: Completion Model Kwargs
+        completion_model_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Completion Model Id
+        wizard:
+          anyOf:
+            - $ref: '#/components/schemas/AssistantTemplateWizard'
+            - type: 'null'
+        icon_name:
+          anyOf:
+            - type: string
+              maxLength: 100
+            - type: 'null'
+          title: Icon Name
+      title: AssistantTemplateAdminUpdate
     AssistantTemplateListPublic:
       type: object
       properties:
         items:
           type: array
           items:
-            "$ref": "#/components/schemas/AssistantTemplatePublic"
+            $ref: '#/components/schemas/AssistantTemplatePublic'
           title: Items
         count:
           type: integer
@@ -9785,15 +16718,24 @@ components:
           type: string
           title: Category
         assistant:
-          "$ref": "#/components/schemas/AssistantInTemplatePublic"
+          $ref: '#/components/schemas/AssistantInTemplatePublic'
         type:
           type: string
           const: assistant
           title: Type
         wizard:
-          "$ref": "#/components/schemas/AssistantTemplateWizard"
+          $ref: '#/components/schemas/AssistantTemplateWizard'
         organization:
-          "$ref": "#/components/schemas/AssistantTemplateOrganization"
+          $ref: '#/components/schemas/AssistantTemplateOrganization'
+        is_default:
+          type: boolean
+          default: false
+          title: Is Default
+        icon_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Icon Name
       required:
         - assistant
         - category
@@ -9806,16 +16748,26 @@ components:
         - updated_at
         - wizard
       title: AssistantTemplatePublic
+    AssistantTemplateToggleDefaultRequest:
+      type: object
+      description: Request to toggle template as default/featured.
+      properties:
+        is_default:
+          type: boolean
+          title: Is Default
+      required:
+        - is_default
+      title: AssistantTemplateToggleDefaultRequest
     AssistantTemplateWizard:
       type: object
       properties:
         attachments:
           anyOf:
-            - "$ref": "#/components/schemas/TemplateWizard"
+            - $ref: '#/components/schemas/TemplateWizard'
             - type: 'null'
         collections:
           anyOf:
-            - "$ref": "#/components/schemas/TemplateWizard"
+            - $ref: '#/components/schemas/TemplateWizard'
             - type: 'null'
       required:
         - attachments
@@ -9833,7 +16785,7 @@ components:
         formats:
           type: array
           items:
-            "$ref": "#/components/schemas/FormatLimit"
+            $ref: '#/components/schemas/FormatLimit'
           title: Formats
         max_in_question:
           type: integer
@@ -9842,6 +16794,180 @@ components:
         - formats
         - max_in_question
       title: AttachmentLimits
+    AuditConfigResponse:
+      type: object
+      description: |-
+        Response model for GET /api/v1/audit/config.
+        Contains all 7 categories with metadata.
+      example:
+        categories:
+          - action_count: 13
+            category: admin_actions
+            description: 'User management, role changes, API keys, tenant settings'
+            enabled: true
+            example_actions:
+              - USER_CREATED
+              - ROLE_DELETED
+              - API_KEY_GENERATED
+          - action_count: 28
+            category: user_actions
+            description: 'Assistant, space, app operations, templates, model configs'
+            enabled: true
+            example_actions:
+              - ASSISTANT_CREATED
+              - SPACE_DELETED
+              - APP_EXECUTED
+      properties:
+        categories:
+          type: array
+          description: List of all audit categories with configuration and metadata
+          items:
+            $ref: '#/components/schemas/CategoryConfig'
+          title: Categories
+      required:
+        - categories
+      title: AuditConfigResponse
+    AuditConfigUpdateRequest:
+      type: object
+      description: |-
+        Request model for PATCH /api/v1/audit/config.
+        Allows bulk updates of multiple categories.
+      example:
+        updates:
+          - category: admin_actions
+            enabled: false
+          - category: file_operations
+            enabled: false
+      properties:
+        updates:
+          type: array
+          description: List of category configuration updates
+          items:
+            $ref: '#/components/schemas/CategoryUpdate'
+          maxItems: 7
+          minItems: 1
+          title: Updates
+      required:
+        - updates
+      title: AuditConfigUpdateRequest
+    AuditLogListResponse:
+      type: object
+      description: Schema for audit log list response.
+      properties:
+        logs:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditLogResponse'
+          title: Logs
+        total_count:
+          type: integer
+          title: Total Count
+        page:
+          type: integer
+          title: Page
+        page_size:
+          type: integer
+          title: Page Size
+        total_pages:
+          type: integer
+          title: Total Pages
+      required:
+        - logs
+        - page
+        - page_size
+        - total_count
+        - total_pages
+      title: AuditLogListResponse
+    AuditLogResponse:
+      type: object
+      description: Schema for audit log response.
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        tenant_id:
+          type: string
+          format: uuid
+          title: Tenant Id
+        actor_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Actor Id
+        actor_type:
+          $ref: '#/components/schemas/ActorType'
+        action:
+          $ref: '#/components/schemas/ActionType'
+        entity_type:
+          $ref: '#/components/schemas/EntityType'
+        entity_id:
+          type: string
+          format: uuid
+          title: Entity Id
+        timestamp:
+          type: string
+          format: date-time
+          title: Timestamp
+        description:
+          type: string
+          title: Description
+        metadata:
+          type: object
+          additionalProperties: true
+          title: Metadata
+        outcome:
+          $ref: '#/components/schemas/Outcome'
+        ip_address:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Ip Address
+        user_agent:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: User Agent
+        request_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Request Id
+        error_message:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Error Message
+        deleted_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Deleted At
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      required:
+        - action
+        - actor_type
+        - created_at
+        - description
+        - entity_id
+        - entity_type
+        - id
+        - metadata
+        - outcome
+        - tenant_id
+        - timestamp
+        - updated_at
+      title: AuditLogResponse
     AuthCallbackParams:
       type: object
       properties:
@@ -9898,6 +17024,16 @@ components:
         - password
         - username
       title: Body_Login_api_v1_users_login_token__post
+    Body_create_icon_api_v1_icons__post:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary
+          title: File
+      required:
+        - file
+      title: Body_create_icon_api_v1_icons__post
     Body_upload_file_api_v1_files__post:
       type: object
       properties:
@@ -9918,6 +17054,135 @@ components:
       required:
         - file
       title: Body_upload_file_api_v1_groups__id__info_blobs_upload__post
+    BulkCrawlRequest:
+      type: object
+      description: Request model for triggering crawls on multiple websites.
+      properties:
+        website_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          title: Website Ids
+      required:
+        - website_ids
+      title: BulkCrawlRequest
+    BulkCrawlResponse:
+      type: object
+      description: Response model for bulk crawl operations.
+      properties:
+        total:
+          type: integer
+          title: Total
+        queued:
+          type: integer
+          title: Queued
+        failed:
+          type: integer
+          title: Failed
+        crawl_runs:
+          type: array
+          items:
+            $ref: >-
+              #/components/schemas/intric__websites__presentation__website_models__CrawlRunPublic
+          title: Crawl Runs
+        errors:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: string
+          title: Errors
+      required:
+        - crawl_runs
+        - errors
+        - failed
+        - queued
+        - total
+      title: BulkCrawlResponse
+    CallbackRequest:
+      type: object
+      description: OIDC callback with authorization code.
+      example:
+        code: authorization_code_from_idp
+        state: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+      properties:
+        code:
+          type: string
+          title: Code
+        state:
+          type: string
+          title: State
+        code_verifier:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Code Verifier
+      required:
+        - code
+        - state
+      title: CallbackRequest
+    CategoryConfig:
+      type: object
+      description: Enriched category configuration with metadata for API responses.
+      example:
+        action_count: 13
+        category: admin_actions
+        description: 'User management, role changes, API keys, tenant settings'
+        enabled: true
+        example_actions:
+          - USER_CREATED
+          - ROLE_DELETED
+          - API_KEY_GENERATED
+      properties:
+        category:
+          type: string
+          description: 'Category name (e.g., ''admin_actions'')'
+          title: Category
+        enabled:
+          type: boolean
+          description: Whether category is currently enabled
+          title: Enabled
+        description:
+          type: string
+          description: Human-readable description of category
+          title: Description
+        action_count:
+          type: integer
+          description: Number of action types in this category
+          title: Action Count
+        example_actions:
+          type: array
+          description: Sample action types (max 3) for UI display
+          items:
+            type: string
+          title: Example Actions
+      required:
+        - action_count
+        - category
+        - description
+        - enabled
+        - example_actions
+      title: CategoryConfig
+    CategoryUpdate:
+      type: object
+      description: Represents a category configuration change request.
+      example:
+        category: admin_actions
+        enabled: false
+      properties:
+        category:
+          type: string
+          description: Category name to update
+          title: Category
+        enabled:
+          type: boolean
+          description: New enabled state
+          title: Enabled
+      required:
+        - category
+        - enabled
+      title: CategoryUpdate
     CollectionMetadata:
       type: object
       properties:
@@ -9954,20 +17219,25 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         name:
           type: string
           title: Name
         embedding_model:
-          "$ref": "#/components/schemas/EmbeddingModelPublic"
+          $ref: '#/components/schemas/EmbeddingModelPublic'
         metadata:
-          "$ref": "#/components/schemas/CollectionMetadata"
+          $ref: '#/components/schemas/CollectionMetadata'
+        space_id:
+          type: string
+          format: uuid
+          title: Space Id
       required:
         - embedding_model
         - id
         - metadata
         - name
+        - space_id
       title: CollectionPublic
     CollectionUpdate:
       type: object
@@ -10004,7 +17274,10 @@ components:
           type: string
           title: Nickname
         family:
-          "$ref": "#/components/schemas/ModelFamily"
+          anyOf:
+            - $ref: '#/components/schemas/ModelFamily'
+            - type: string
+          title: Family
         token_limit:
           type: integer
           title: Token Limit
@@ -10022,9 +17295,15 @@ components:
             - type: 'null'
           title: Hf Link
         stability:
-          "$ref": "#/components/schemas/ModelStability"
+          anyOf:
+            - $ref: '#/components/schemas/ModelStability'
+            - type: string
+          title: Stability
         hosting:
-          "$ref": "#/components/schemas/ModelHostingLocation"
+          anyOf:
+            - $ref: '#/components/schemas/ModelHostingLocation'
+            - type: string
+          title: Hosting
         open_source:
           anyOf:
             - type: boolean
@@ -10042,8 +17321,10 @@ components:
           title: Deployment Name
         org:
           anyOf:
-            - "$ref": "#/components/schemas/ModelOrg"
+            - $ref: '#/components/schemas/ModelOrg'
+            - type: string
             - type: 'null'
+          title: Org
         vision:
           type: boolean
           title: Vision
@@ -10068,6 +17349,18 @@ components:
           type: boolean
           default: false
           title: Is Org Default
+        tenant_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Tenant Id
+        provider_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Provider Id
       required:
         - family
         - hosting
@@ -10080,6 +17373,94 @@ components:
         - token_limit
         - vision
       title: CompletionModel
+    CompletionModelCreate:
+      type: object
+      properties:
+        name:
+          type: string
+          title: Name
+        nickname:
+          type: string
+          title: Nickname
+        family:
+          anyOf:
+            - $ref: '#/components/schemas/ModelFamily'
+            - type: string
+          title: Family
+        token_limit:
+          type: integer
+          title: Token Limit
+        is_deprecated:
+          type: boolean
+          title: Is Deprecated
+        nr_billion_parameters:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Nr Billion Parameters
+        hf_link:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Hf Link
+        stability:
+          anyOf:
+            - $ref: '#/components/schemas/ModelStability'
+            - type: string
+          title: Stability
+        hosting:
+          anyOf:
+            - $ref: '#/components/schemas/ModelHostingLocation'
+            - type: string
+          title: Hosting
+        open_source:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          title: Open Source
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Description
+        deployment_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Deployment Name
+        org:
+          anyOf:
+            - $ref: '#/components/schemas/ModelOrg'
+            - type: string
+            - type: 'null'
+          title: Org
+        vision:
+          type: boolean
+          title: Vision
+        reasoning:
+          type: boolean
+          title: Reasoning
+        base_url:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Base Url
+        litellm_model_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Litellm Model Name
+      required:
+        - family
+        - hosting
+        - is_deprecated
+        - name
+        - nickname
+        - reasoning
+        - stability
+        - token_limit
+        - vision
+      title: CompletionModelCreate
     CompletionModelPublic:
       type: object
       properties:
@@ -10106,7 +17487,10 @@ components:
           type: string
           title: Nickname
         family:
-          "$ref": "#/components/schemas/ModelFamily"
+          anyOf:
+            - $ref: '#/components/schemas/ModelFamily'
+            - type: string
+          title: Family
         token_limit:
           type: integer
           title: Token Limit
@@ -10124,9 +17508,15 @@ components:
             - type: 'null'
           title: Hf Link
         stability:
-          "$ref": "#/components/schemas/ModelStability"
+          anyOf:
+            - $ref: '#/components/schemas/ModelStability'
+            - type: string
+          title: Stability
         hosting:
-          "$ref": "#/components/schemas/ModelHostingLocation"
+          anyOf:
+            - $ref: '#/components/schemas/ModelHostingLocation'
+            - type: string
+          title: Hosting
         open_source:
           anyOf:
             - type: boolean
@@ -10144,8 +17534,10 @@ components:
           title: Deployment Name
         org:
           anyOf:
-            - "$ref": "#/components/schemas/ModelOrg"
+            - $ref: '#/components/schemas/ModelOrg'
+            - type: string
             - type: 'null'
+          title: Org
         vision:
           type: boolean
           title: Vision
@@ -10170,6 +17562,18 @@ components:
           type: boolean
           default: false
           title: Is Org Default
+        tenant_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Tenant Id
+        provider_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Provider Id
         can_access:
           type: boolean
           default: false
@@ -10178,10 +17582,30 @@ components:
           type: boolean
           default: true
           title: Is Locked
+        lock_reason:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Lock Reason
+        credential_provider:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Credential Provider
         security_classification:
           anyOf:
-            - "$ref": "#/components/schemas/SecurityClassificationPublic"
+            - $ref: '#/components/schemas/SecurityClassificationPublic'
             - type: 'null'
+        provider_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Name
+        provider_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Type
       required:
         - family
         - hosting
@@ -10240,7 +17664,10 @@ components:
           type: string
           title: Nickname
         family:
-          "$ref": "#/components/schemas/ModelFamily"
+          anyOf:
+            - $ref: '#/components/schemas/ModelFamily'
+            - type: string
+          title: Family
         token_limit:
           type: integer
           title: Token Limit
@@ -10258,9 +17685,15 @@ components:
             - type: 'null'
           title: Hf Link
         stability:
-          "$ref": "#/components/schemas/ModelStability"
+          anyOf:
+            - $ref: '#/components/schemas/ModelStability'
+            - type: string
+          title: Stability
         hosting:
-          "$ref": "#/components/schemas/ModelHostingLocation"
+          anyOf:
+            - $ref: '#/components/schemas/ModelHostingLocation'
+            - type: string
+          title: Hosting
         open_source:
           anyOf:
             - type: boolean
@@ -10278,8 +17711,10 @@ components:
           title: Deployment Name
         org:
           anyOf:
-            - "$ref": "#/components/schemas/ModelOrg"
+            - $ref: '#/components/schemas/ModelOrg'
+            - type: string
             - type: 'null'
+          title: Org
         vision:
           type: boolean
           title: Vision
@@ -10304,6 +17739,18 @@ components:
           type: boolean
           default: false
           title: Is Org Default
+        tenant_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Tenant Id
+        provider_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Provider Id
         can_access:
           type: boolean
           default: false
@@ -10312,10 +17759,30 @@ components:
           type: boolean
           default: true
           title: Is Locked
+        lock_reason:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Lock Reason
+        credential_provider:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Credential Provider
         security_classification:
           anyOf:
-            - "$ref": "#/components/schemas/SecurityClassificationPublic"
+            - $ref: '#/components/schemas/SecurityClassificationPublic'
             - type: 'null'
+        provider_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Name
+        provider_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Type
         meets_security_classification:
           anyOf:
             - type: boolean
@@ -10359,7 +17826,10 @@ components:
           type: string
           title: Nickname
         family:
-          "$ref": "#/components/schemas/ModelFamily"
+          anyOf:
+            - $ref: '#/components/schemas/ModelFamily'
+            - type: string
+          title: Family
         token_limit:
           type: integer
           title: Token Limit
@@ -10377,9 +17847,15 @@ components:
             - type: 'null'
           title: Hf Link
         stability:
-          "$ref": "#/components/schemas/ModelStability"
+          anyOf:
+            - $ref: '#/components/schemas/ModelStability'
+            - type: string
+          title: Stability
         hosting:
-          "$ref": "#/components/schemas/ModelHostingLocation"
+          anyOf:
+            - $ref: '#/components/schemas/ModelHostingLocation'
+            - type: string
+          title: Hosting
         open_source:
           anyOf:
             - type: boolean
@@ -10397,8 +17873,10 @@ components:
           title: Deployment Name
         org:
           anyOf:
-            - "$ref": "#/components/schemas/ModelOrg"
+            - $ref: '#/components/schemas/ModelOrg'
+            - type: string
             - type: 'null'
+          title: Org
         vision:
           type: boolean
           title: Vision
@@ -10442,7 +17920,7 @@ components:
           title: Is Org Default
         security_classification:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
           title: Security Classification
       title: CompletionModelUpdateFlags
@@ -10467,16 +17945,24 @@ components:
       title: ConversationInsightResponse
     ConversationRequest:
       type: object
-      description: |-
-        A unified model for asking questions to either assistants or group chats.
+      description: >-
+        A unified model for asking questions to either assistants or group
+        chats.
+
 
         Either session_id, assistant_id, or group_chat_id must be provided.
-        If session_id is provided, the conversation will continue with the existing session.
+
+        If session_id is provided, the conversation will continue with the
+        existing session.
+
 
         For group chats:
-        - If tools.assistants contains an assistant, that specific assistant will be targeted
+
+        - If tools.assistants contains an assistant, that specific assistant
+        will be targeted
           (requires the group chat to have allow_mentions=True).
-        - If no assistant is targeted, the most appropriate assistant will be selected.
+        - If no assistant is targeted, the most appropriate assistant will be
+        selected.
       properties:
         question:
           type: string
@@ -10503,8 +17989,8 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ModelId"
-          maxItems: 1
+            $ref: '#/components/schemas/ModelId'
+          maxItems: 20
           title: Files
         stream:
           type: boolean
@@ -10512,7 +17998,7 @@ components:
           title: Stream
         tools:
           anyOf:
-            - "$ref": "#/components/schemas/UseTools"
+            - $ref: '#/components/schemas/UseTools'
             - type: 'null'
         use_web_search:
           type: boolean
@@ -10544,6 +18030,360 @@ components:
         - crawl
         - sitemap
       title: CrawlType
+    CrawlerActivity:
+      type: object
+      description: Real-time crawler activity from multiple sources.
+      properties:
+        db_in_progress:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Db In Progress
+        db_query_ok:
+          type: boolean
+          default: true
+          title: Db Query Ok
+        arq_ongoing:
+          type: integer
+          default: 0
+          title: Arq Ongoing
+        delta:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Delta
+      title: CrawlerActivity
+    CrawlerHealthResponse:
+      type: object
+      description: Crawler health status with operator-friendly signals.
+      properties:
+        status:
+          type: string
+          title: Status
+        status_flags:
+          type: array
+          default: []
+          items:
+            type: string
+          title: Status Flags
+        status_reason:
+          type: string
+          default: ''
+          title: Status Reason
+        response_timestamp_utc:
+          type: string
+          title: Response Timestamp Utc
+        crawler_activity:
+          $ref: '#/components/schemas/CrawlerActivity'
+          default:
+            db_query_ok: true
+            arq_ongoing: 0
+        arq:
+          $ref: '#/components/schemas/ARQHealth'
+          default:
+            j_complete: 0
+            j_failed: 0
+            j_retried: 0
+            j_ongoing: 0
+            queued: 0
+        watchdog:
+          $ref: '#/components/schemas/WatchdogMetrics'
+          default:
+            zombies_reconciled: 0
+            expired_killed: 0
+            rescued: 0
+            early_zombies_failed: 0
+            long_running_failed: 0
+            slots_released: 0
+        feeder:
+          $ref: '#/components/schemas/FeederLeader'
+          default:
+            status: UNKNOWN
+        pending:
+          $ref: '#/components/schemas/PendingQueueSummary'
+          default:
+            total: 0
+            tenant_count: 0
+            top_tenants: {}
+        thresholds:
+          $ref: '#/components/schemas/HealthThresholds'
+        debug:
+          $ref: '#/components/schemas/DebugInfo'
+          default:
+            arq_raw: ''
+            queue_name: 'arq:queue'
+      required:
+        - response_timestamp_utc
+        - status
+        - thresholds
+      title: CrawlerHealthResponse
+    CrawlerSettingsResponse:
+      type: object
+      description: |-
+        Response model for crawler settings operations.
+
+        Returns current settings merged with environment defaults.
+        Tenant overrides are highlighted.
+
+        Example:
+            {
+                "tenant_id": "123e4567-e89b-12d3-a456-426614174000",
+                "settings": {
+                    "crawl_max_length": 14400,
+                    "download_timeout": 90,
+                    "download_max_size": 10485760,
+                    "dns_timeout": 30,
+                    "retry_times": 2,
+                    "closespider_itemcount": 20000,
+                    "obey_robots": true,
+                    "autothrottle_enabled": true,
+                    "tenant_worker_concurrency_limit": 4,
+                    "crawl_stale_threshold_minutes": 30,
+                    "crawl_heartbeat_interval_seconds": 300,
+                    "crawl_feeder_enabled": false,
+                    "crawl_feeder_interval_seconds": 10,
+                    "crawl_feeder_batch_size": 10,
+                    "crawl_job_max_age_seconds": 1800
+                },
+                "overrides": ["download_timeout", "dns_timeout"],
+                "updated_at": "2025-10-22T10:00:00+00:00"
+            }
+      properties:
+        tenant_id:
+          type: string
+          format: uuid
+          description: Tenant UUID
+          title: Tenant Id
+        settings:
+          type: object
+          additionalProperties: true
+          description: Current effective settings (tenant overrides + env defaults)
+          examples:
+            - autothrottle_enabled: true
+              closespider_itemcount: 20000
+              crawl_feeder_batch_size: 10
+              crawl_feeder_enabled: false
+              crawl_feeder_interval_seconds: 10
+              crawl_heartbeat_interval_seconds: 300
+              crawl_job_max_age_seconds: 1800
+              crawl_max_length: 14400
+              crawl_stale_threshold_minutes: 30
+              dns_timeout: 30
+              download_max_size: 10485760
+              download_timeout: 90
+              obey_robots: true
+              retry_times: 2
+              tenant_worker_concurrency_limit: 4
+          title: Settings
+        overrides:
+          type: array
+          description: List of setting keys that have tenant-specific overrides
+          examples:
+            - - download_timeout
+              - dns_timeout
+          items:
+            type: string
+          title: Overrides
+        updated_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          description: Timestamp of last settings update
+          title: Updated At
+      required:
+        - overrides
+        - settings
+        - tenant_id
+      title: CrawlerSettingsResponse
+    CrawlerSettingsUpdate:
+      type: object
+      description: >-
+        Request model for updating tenant crawler settings.
+
+
+        All fields are optional - only provided fields will be updated.
+
+        Missing fields retain their previous values or fall back to environment
+        defaults.
+
+
+        Field constraints are derived from CRAWLER_SETTING_SPECS (single source
+        of truth).
+
+
+        Example - Full configuration:
+            {
+                "crawl_max_length": 14400,
+                "download_timeout": 90,
+                "download_max_size": 10485760,
+                "dns_timeout": 30,
+                "retry_times": 2,
+                "closespider_itemcount": 20000,
+                "obey_robots": true,
+                "autothrottle_enabled": true,
+                "tenant_worker_concurrency_limit": 4,
+                "crawl_stale_threshold_minutes": 30,
+                "crawl_heartbeat_interval_seconds": 300,
+                "crawl_feeder_enabled": false,
+                "crawl_feeder_interval_seconds": 10,
+                "crawl_feeder_batch_size": 10,
+                "crawl_job_max_age_seconds": 1800
+            }
+
+        Example - Partial update (adjust timeouts only):
+            {
+                "download_timeout": 120,
+                "dns_timeout": 45
+            }
+      properties:
+        crawl_max_length:
+          anyOf:
+            - type: integer
+              maximum: 86400
+              minimum: 60
+            - type: 'null'
+          description: Maximum crawl duration in seconds (1 min to 24 hours)
+          examples:
+            - 14400
+          title: Crawl Max Length
+        download_timeout:
+          anyOf:
+            - type: integer
+              maximum: 300
+              minimum: 10
+            - type: 'null'
+          description: Per-request download timeout in seconds (10s to 5 min)
+          examples:
+            - 90
+          title: Download Timeout
+        download_max_size:
+          anyOf:
+            - type: integer
+              maximum: 1073741824
+              minimum: 1048576
+            - type: 'null'
+          description: Maximum file size for crawler downloads in bytes (1MB to 1GB)
+          examples:
+            - 10485760
+          title: Download Max Size
+        dns_timeout:
+          anyOf:
+            - type: integer
+              maximum: 120
+              minimum: 5
+            - type: 'null'
+          description: DNS resolution timeout in seconds (5s to 2 min)
+          examples:
+            - 30
+          title: Dns Timeout
+        retry_times:
+          anyOf:
+            - type: integer
+              maximum: 10
+              minimum: 0
+            - type: 'null'
+          description: Number of retry attempts per request (0 to 10)
+          examples:
+            - 2
+          title: Retry Times
+        closespider_itemcount:
+          anyOf:
+            - type: integer
+              maximum: 100000
+              minimum: 100
+            - type: 'null'
+          description: Maximum pages to crawl before stopping (100 to 100k)
+          examples:
+            - 20000
+          title: Closespider Itemcount
+        obey_robots:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          description: Whether to respect robots.txt rules
+          examples:
+            - true
+          title: Obey Robots
+        autothrottle_enabled:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          description: Enable automatic request throttling based on server response times
+          examples:
+            - true
+          title: Autothrottle Enabled
+        tenant_worker_concurrency_limit:
+          anyOf:
+            - type: integer
+              maximum: 50
+              minimum: 0
+            - type: 'null'
+          description: 'Maximum concurrent crawl jobs per tenant (0 = unlimited, 1 to 50)'
+          examples:
+            - 4
+          title: Tenant Worker Concurrency Limit
+        crawl_stale_threshold_minutes:
+          anyOf:
+            - type: integer
+              maximum: 1440
+              minimum: 5
+            - type: 'null'
+          description: >-
+            Minutes without activity before IN_PROGRESS job is considered stale
+            (5 min to 24 hours)
+          examples:
+            - 30
+          title: Crawl Stale Threshold Minutes
+        crawl_heartbeat_interval_seconds:
+          anyOf:
+            - type: integer
+              maximum: 3600
+              minimum: 30
+            - type: 'null'
+          description: Heartbeat interval to signal job is alive (30s to 1 hour)
+          examples:
+            - 300
+          title: Crawl Heartbeat Interval Seconds
+        crawl_feeder_enabled:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          description: Enable crawl feeder service for rate-limited job enqueueing
+          examples:
+            - false
+          title: Crawl Feeder Enabled
+        crawl_feeder_interval_seconds:
+          anyOf:
+            - type: integer
+              maximum: 300
+              minimum: 5
+            - type: 'null'
+          description: Feeder check interval in seconds (5s to 5 min)
+          examples:
+            - 10
+          title: Crawl Feeder Interval Seconds
+        crawl_feeder_batch_size:
+          anyOf:
+            - type: integer
+              maximum: 100
+              minimum: 1
+            - type: 'null'
+          description: Maximum jobs to enqueue per feeder cycle per tenant (1 to 100)
+          examples:
+            - 10
+          title: Crawl Feeder Batch Size
+        crawl_job_max_age_seconds:
+          anyOf:
+            - type: integer
+              maximum: 7200
+              minimum: 300
+            - type: 'null'
+          description: Maximum job retry age before permanent failure (5 min to 2 hours)
+          examples:
+            - 1800
+          title: Crawl Job Max Age Seconds
+      title: CrawlerSettingsUpdate
     CreateGroupRequest:
       type: object
       properties:
@@ -10551,7 +18391,7 @@ components:
           type: string
           title: Name
         embedding_model:
-          "$ref": "#/components/schemas/ModelId"
+          $ref: '#/components/schemas/ModelId'
       required:
         - embedding_model
         - name
@@ -10564,7 +18404,7 @@ components:
           title: Name
         from_template:
           anyOf:
-            - "$ref": "#/components/schemas/TemplateCreate"
+            - $ref: '#/components/schemas/TemplateCreate'
             - type: 'null'
       required:
         - name
@@ -10577,7 +18417,7 @@ components:
           title: Name
         from_template:
           anyOf:
-            - "$ref": "#/components/schemas/TemplateCreate"
+            - $ref: '#/components/schemas/TemplateCreate'
             - type: 'null'
       required:
         - name
@@ -10590,7 +18430,7 @@ components:
           title: Name
         embedding_model:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
       required:
         - name
@@ -10602,7 +18442,7 @@ components:
           type: string
           title: Name
         embedding_model:
-          "$ref": "#/components/schemas/ModelId"
+          $ref: '#/components/schemas/ModelId'
         url:
           type: string
           title: Url
@@ -10611,11 +18451,146 @@ components:
             - type: string
             - type: 'null'
           title: Key
+        folder_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Folder Id
+        folder_path:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Folder Path
+        selected_item_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Selected Item Type
+        resource_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          default: site
+          title: Resource Type
       required:
         - embedding_model
         - name
         - url
       title: CreateSpaceIntegrationKnowledge
+    CreateSpaceIntegrationKnowledgeBatchItem:
+      type: object
+      properties:
+        name:
+          type: string
+          title: Name
+        url:
+          type: string
+          title: Url
+        key:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Key
+        folder_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Folder Id
+        folder_path:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Folder Path
+        selected_item_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Selected Item Type
+        resource_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          default: site
+          title: Resource Type
+      required:
+        - name
+        - url
+      title: CreateSpaceIntegrationKnowledgeBatchItem
+    CreateSpaceIntegrationKnowledgeBatchRequest:
+      type: object
+      properties:
+        embedding_model:
+          $ref: '#/components/schemas/ModelId'
+        wrapper_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Wrapper Name
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreateSpaceIntegrationKnowledgeBatchItem'
+          maxItems: 50
+          minItems: 1
+          title: Items
+      required:
+        - embedding_model
+        - items
+      title: CreateSpaceIntegrationKnowledgeBatchRequest
+    CreateSpaceIntegrationKnowledgeBatchResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreateSpaceIntegrationKnowledgeBatchResult'
+          title: Items
+        created_count:
+          type: integer
+          title: Created Count
+        failed_count:
+          type: integer
+          title: Failed Count
+      required:
+        - created_count
+        - failed_count
+        - items
+      title: CreateSpaceIntegrationKnowledgeBatchResponse
+    CreateSpaceIntegrationKnowledgeBatchResult:
+      type: object
+      properties:
+        index:
+          type: integer
+          title: Index
+        name:
+          type: string
+          title: Name
+        status:
+          type: string
+          enum:
+            - created
+            - failed
+          title: Status
+        integration_knowledge_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Integration Knowledge Id
+        job:
+          anyOf:
+            - $ref: '#/components/schemas/JobPublic'
+            - type: 'null'
+        error:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Error
+      required:
+        - index
+        - name
+        - status
+      title: CreateSpaceIntegrationKnowledgeBatchResult
     CreateSpaceRequest:
       type: object
       properties:
@@ -10641,7 +18616,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         created_at:
           anyOf:
@@ -10666,7 +18641,7 @@ components:
           type: string
           title: Prompt
         completion_model_kwargs:
-          "$ref": "#/components/schemas/ModelKwargs"
+          $ref: '#/components/schemas/ModelKwargs'
         output_format:
           anyOf:
             - type: string
@@ -10685,18 +18660,18 @@ components:
         groups:
           type: array
           items:
-            "$ref": "#/components/schemas/GroupPublicWithMetadata"
+            $ref: '#/components/schemas/GroupPublicWithMetadata'
           title: Groups
         completion_model:
           anyOf:
-            - "$ref": "#/components/schemas/CompletionModelSparse"
+            - $ref: '#/components/schemas/CompletionModelSparse'
             - type: 'null'
         published:
           type: boolean
           default: false
           title: Published
         user:
-          "$ref": "#/components/schemas/UserSparse"
+          $ref: '#/components/schemas/UserSparse'
       required:
         - completion_model
         - completion_model_kwargs
@@ -10713,7 +18688,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/SessionMetadataPublic"
+            $ref: '#/components/schemas/SessionMetadataPublic'
           title: Items
         limit:
           anyOf:
@@ -10746,7 +18721,7 @@ components:
         - count
         - items
         - total_count
-      title: CursorPaginatedResponse[SessionMetadataPublic]
+      title: 'CursorPaginatedResponse[SessionMetadataPublic]'
     CursorPaginatedResponse_UserSparse_:
       type: object
       properties:
@@ -10754,7 +18729,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/UserSparse"
+            $ref: '#/components/schemas/UserSparse'
           title: Items
         limit:
           anyOf:
@@ -10787,15 +18762,43 @@ components:
         - count
         - items
         - total_count
-      title: CursorPaginatedResponse[UserSparse]
+      title: 'CursorPaginatedResponse[UserSparse]'
     Dashboard:
       type: object
       properties:
         spaces:
-          "$ref": "#/components/schemas/PaginatedResponse_SpaceDashboard_"
+          $ref: '#/components/schemas/PaginatedResponse_SpaceDashboard_'
       required:
         - spaces
       title: Dashboard
+    DebugInfo:
+      type: object
+      description: 'Raw data for debugging - noisy, not for quick reads.'
+      properties:
+        arq_raw:
+          type: string
+          default: ''
+          title: Arq Raw
+        arq_timestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Arq Timestamp
+        watchdog_timestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Watchdog Timestamp
+        redis_db:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Redis Db
+        queue_name:
+          type: string
+          default: 'arq:queue'
+          title: Queue Name
+      title: DebugInfo
     DefaultAssistant:
       type: object
       properties:
@@ -10803,7 +18806,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         created_at:
           anyOf:
@@ -10826,61 +18829,73 @@ components:
           title: Name
         prompt:
           anyOf:
-            - "$ref": "#/components/schemas/PromptPublic"
+            - $ref: '#/components/schemas/PromptPublic'
             - type: 'null'
         space_id:
           type: string
           format: uuid
           title: Space Id
         completion_model_kwargs:
-          "$ref": "#/components/schemas/ModelKwargs"
+          $ref: '#/components/schemas/ModelKwargs'
         logging_enabled:
           type: boolean
           title: Logging Enabled
         attachments:
           type: array
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Attachments
         allowed_attachments:
-          "$ref": "#/components/schemas/FileRestrictions"
+          $ref: '#/components/schemas/FileRestrictions'
         groups:
           type: array
           items:
-            "$ref": "#/components/schemas/CollectionPublic"
+            $ref: '#/components/schemas/CollectionPublic'
           title: Groups
         websites:
           type: array
           items:
-            "$ref": "#/components/schemas/WebsitePublic"
+            $ref: '#/components/schemas/WebsitePublic'
           title: Websites
         integration_knowledge_list:
           type: array
           items:
-            "$ref": "#/components/schemas/IntegrationKnowledgePublic"
+            $ref: '#/components/schemas/IntegrationKnowledgePublic'
           title: Integration Knowledge List
         completion_model:
           anyOf:
-            - "$ref": "#/components/schemas/CompletionModelSparse"
+            - $ref: '#/components/schemas/CompletionModelSparse'
             - type: 'null'
         published:
           type: boolean
           default: false
           title: Published
         user:
-          "$ref": "#/components/schemas/UserSparse"
+          $ref: '#/components/schemas/UserSparse'
         tools:
-          "$ref": "#/components/schemas/UseTools"
+          $ref: '#/components/schemas/UseTools'
         type:
-          "$ref": "#/components/schemas/AssistantType"
+          $ref: '#/components/schemas/AssistantType'
+        model_info:
+          anyOf:
+            - $ref: '#/components/schemas/ModelInfo'
+            - type: 'null'
         description:
           anyOf:
             - type: string
             - type: 'null'
-          description: A description of the assitant that will be used as default
+          description: >-
+            A description of the assitant that will be used as default
             description in GroupChatAssistantPublic
           example: This is a helpful AI assistant
           title: Description
+        icon_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Icon ID referencing an uploaded icon
+          title: Icon Id
         insight_enabled:
           type: boolean
           default: false
@@ -10913,6 +18928,48 @@ components:
         - user
         - websites
       title: DefaultAssistant
+    DeleteCredentialResponse:
+      type: object
+      description: |-
+        Response model for deleting tenant API credentials.
+
+        Example:
+            {
+                "tenant_id": "123e4567-e89b-12d3-a456-426614174000",
+                "provider": "anthropic",
+                "message": "API credential for anthropic deleted successfully"
+            }
+      properties:
+        tenant_id:
+          type: string
+          format: uuid
+          title: Tenant Id
+        provider:
+          type: string
+          title: Provider
+        message:
+          type: string
+          title: Message
+      required:
+        - message
+        - provider
+        - tenant_id
+      title: DeleteCredentialResponse
+    DeleteFederationResponse:
+      type: object
+      description: Response model for deleting federation config.
+      properties:
+        tenant_id:
+          type: string
+          format: uuid
+          title: Tenant Id
+        message:
+          type: string
+          title: Message
+      required:
+        - message
+        - tenant_id
+      title: DeleteFederationResponse
     DeleteResponse:
       type: object
       properties:
@@ -10922,6 +18979,98 @@ components:
       required:
         - success
       title: DeleteResponse
+    DeleteSettingsResponse:
+      type: object
+      description: |-
+        Response model for deleting tenant crawler settings.
+
+        Example:
+            {
+                "tenant_id": "123e4567-e89b-12d3-a456-426614174000",
+                "message": "Crawler settings reset to defaults",
+                "deleted_keys": ["download_timeout", "dns_timeout"]
+            }
+      properties:
+        tenant_id:
+          type: string
+          format: uuid
+          description: Tenant UUID
+          title: Tenant Id
+        message:
+          type: string
+          description: Confirmation message
+          title: Message
+        deleted_keys:
+          type: array
+          description: List of setting keys that were removed
+          items:
+            type: string
+          title: Deleted Keys
+      required:
+        - deleted_keys
+        - message
+        - tenant_id
+      title: DeleteSettingsResponse
+    EmbeddingModelCreate:
+      type: object
+      properties:
+        name:
+          type: string
+          title: Name
+        family:
+          $ref: '#/components/schemas/EmbeddingModelFamily'
+        is_deprecated:
+          type: boolean
+          title: Is Deprecated
+        open_source:
+          type: boolean
+          title: Open Source
+        dimensions:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Dimensions
+        max_input:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Max Input
+        max_batch_size:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Max Batch Size
+        hf_link:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Hf Link
+        stability:
+          $ref: '#/components/schemas/ModelStability'
+        hosting:
+          $ref: '#/components/schemas/ModelHostingLocation'
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Description
+        org:
+          anyOf:
+            - $ref: '#/components/schemas/ModelOrg'
+            - type: 'null'
+        litellm_model_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Litellm Model Name
+      required:
+        - family
+        - hosting
+        - is_deprecated
+        - name
+        - open_source
+        - stability
+      title: EmbeddingModelCreate
     EmbeddingModelFamily:
       type: string
       enum:
@@ -10952,7 +19101,7 @@ components:
           type: string
           title: Name
         family:
-          "$ref": "#/components/schemas/EmbeddingModelFamily"
+          $ref: '#/components/schemas/EmbeddingModelFamily'
         is_deprecated:
           type: boolean
           title: Is Deprecated
@@ -10969,15 +19118,20 @@ components:
             - type: integer
             - type: 'null'
           title: Max Input
+        max_batch_size:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Max Batch Size
         hf_link:
           anyOf:
             - type: string
             - type: 'null'
           title: Hf Link
         stability:
-          "$ref": "#/components/schemas/ModelStability"
+          $ref: '#/components/schemas/ModelStability'
         hosting:
-          "$ref": "#/components/schemas/ModelHostingLocation"
+          $ref: '#/components/schemas/ModelHostingLocation'
         description:
           anyOf:
             - type: string
@@ -10985,7 +19139,7 @@ components:
           title: Description
         org:
           anyOf:
-            - "$ref": "#/components/schemas/ModelOrg"
+            - $ref: '#/components/schemas/ModelOrg'
             - type: 'null'
         litellm_model_name:
           anyOf:
@@ -11028,7 +19182,7 @@ components:
           type: string
           title: Name
         family:
-          "$ref": "#/components/schemas/ModelFamily"
+          $ref: '#/components/schemas/ModelFamily'
         is_deprecated:
           type: boolean
           title: Is Deprecated
@@ -11051,9 +19205,9 @@ components:
             - type: 'null'
           title: Hf Link
         stability:
-          "$ref": "#/components/schemas/ModelStability"
+          $ref: '#/components/schemas/ModelStability'
         hosting:
-          "$ref": "#/components/schemas/ModelHostingLocation"
+          $ref: '#/components/schemas/ModelHostingLocation'
         description:
           anyOf:
             - type: string
@@ -11061,8 +19215,13 @@ components:
           title: Description
         org:
           anyOf:
-            - "$ref": "#/components/schemas/ModelOrg"
+            - $ref: '#/components/schemas/ModelOrg'
             - type: 'null'
+        litellm_model_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Litellm Model Name
         can_access:
           type: boolean
           default: false
@@ -11071,14 +19230,46 @@ components:
           type: boolean
           default: true
           title: Is Locked
+        lock_reason:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Lock Reason
         is_org_enabled:
           type: boolean
           default: false
           title: Is Org Enabled
+        credential_provider:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Credential Provider
         security_classification:
           anyOf:
-            - "$ref": "#/components/schemas/SecurityClassificationPublic"
+            - $ref: '#/components/schemas/SecurityClassificationPublic'
             - type: 'null'
+        tenant_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Tenant Id
+        provider_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Provider Id
+        provider_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Name
+        provider_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Type
       required:
         - family
         - hosting
@@ -11111,7 +19302,7 @@ components:
           type: string
           title: Name
         family:
-          "$ref": "#/components/schemas/EmbeddingModelFamily"
+          $ref: '#/components/schemas/EmbeddingModelFamily'
         is_deprecated:
           type: boolean
           title: Is Deprecated
@@ -11128,15 +19319,20 @@ components:
             - type: integer
             - type: 'null'
           title: Max Input
+        max_batch_size:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Max Batch Size
         hf_link:
           anyOf:
             - type: string
             - type: 'null'
           title: Hf Link
         stability:
-          "$ref": "#/components/schemas/ModelStability"
+          $ref: '#/components/schemas/ModelStability'
         hosting:
-          "$ref": "#/components/schemas/ModelHostingLocation"
+          $ref: '#/components/schemas/ModelHostingLocation'
         description:
           anyOf:
             - type: string
@@ -11144,7 +19340,7 @@ components:
           title: Description
         org:
           anyOf:
-            - "$ref": "#/components/schemas/ModelOrg"
+            - $ref: '#/components/schemas/ModelOrg'
             - type: 'null'
         litellm_model_name:
           anyOf:
@@ -11163,6 +19359,11 @@ components:
           type: boolean
           default: true
           title: Is Locked
+        lock_reason:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Lock Reason
       required:
         - family
         - hosting
@@ -11195,7 +19396,7 @@ components:
           type: string
           title: Name
         family:
-          "$ref": "#/components/schemas/ModelFamily"
+          $ref: '#/components/schemas/ModelFamily'
         is_deprecated:
           type: boolean
           title: Is Deprecated
@@ -11218,9 +19419,9 @@ components:
             - type: 'null'
           title: Hf Link
         stability:
-          "$ref": "#/components/schemas/ModelStability"
+          $ref: '#/components/schemas/ModelStability'
         hosting:
-          "$ref": "#/components/schemas/ModelHostingLocation"
+          $ref: '#/components/schemas/ModelHostingLocation'
         description:
           anyOf:
             - type: string
@@ -11228,8 +19429,13 @@ components:
           title: Description
         org:
           anyOf:
-            - "$ref": "#/components/schemas/ModelOrg"
+            - $ref: '#/components/schemas/ModelOrg'
             - type: 'null'
+        litellm_model_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Litellm Model Name
         can_access:
           type: boolean
           default: false
@@ -11238,14 +19444,46 @@ components:
           type: boolean
           default: true
           title: Is Locked
+        lock_reason:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Lock Reason
         is_org_enabled:
           type: boolean
           default: false
           title: Is Org Enabled
+        credential_provider:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Credential Provider
         security_classification:
           anyOf:
-            - "$ref": "#/components/schemas/SecurityClassificationPublic"
+            - $ref: '#/components/schemas/SecurityClassificationPublic'
             - type: 'null'
+        tenant_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Tenant Id
+        provider_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Provider Id
+        provider_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Name
+        provider_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Type
         meets_security_classification:
           anyOf:
             - type: boolean
@@ -11260,6 +19498,83 @@ components:
         - open_source
         - stability
       title: EmbeddingModelSecurityStatus
+    EmbeddingModelSparse:
+      type: object
+      properties:
+        created_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Created At
+        updated_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Updated At
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        family:
+          $ref: '#/components/schemas/EmbeddingModelFamily'
+        is_deprecated:
+          type: boolean
+          title: Is Deprecated
+        open_source:
+          type: boolean
+          title: Open Source
+        dimensions:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Dimensions
+        max_input:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Max Input
+        max_batch_size:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Max Batch Size
+        hf_link:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Hf Link
+        stability:
+          $ref: '#/components/schemas/ModelStability'
+        hosting:
+          $ref: '#/components/schemas/ModelHostingLocation'
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Description
+        org:
+          anyOf:
+            - $ref: '#/components/schemas/ModelOrg'
+            - type: 'null'
+        litellm_model_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Litellm Model Name
+      required:
+        - family
+        - hosting
+        - id
+        - is_deprecated
+        - name
+        - open_source
+        - stability
+      title: EmbeddingModelSparse
     EmbeddingModelUpdate:
       type: object
       properties:
@@ -11268,7 +19583,7 @@ components:
           title: Is Org Enabled
         security_classification:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
           title: Security Classification
       title: EmbeddingModelUpdate
@@ -11282,6 +19597,34 @@ components:
           default: false
           title: Is Org Enabled
       title: EmbeddingModelUpdateFlags
+    EntityType:
+      type: string
+      description: Categorize what type of entity was affected
+      enum:
+        - user
+        - assistant
+        - space
+        - app
+        - file
+        - website
+        - tenant_settings
+        - credential
+        - federation_config
+        - api_key
+        - role
+        - module
+        - template
+        - group_chat
+        - collection
+        - app_run
+        - security_classification
+        - integration
+        - integration_knowledge
+        - completion_model
+        - embedding_model
+        - transcription_model
+        - audit_log
+      title: EntityType
     ErrorCodes:
       type: integer
       enum:
@@ -11311,7 +19654,253 @@ components:
         - 9023
         - 9024
         - 9025
+        - 9026
+        - 9027
+        - 9028
+        - 9029
+        - 9030
+        - 9031
+        - 9032
       title: ErrorCodes
+    ExportJobRequest:
+      type: object
+      description: Schema for requesting async audit log export.
+      properties:
+        user_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: User ID for GDPR export
+          title: User Id
+        actor_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Filter by actor
+          title: Actor Id
+        action:
+          anyOf:
+            - $ref: '#/components/schemas/ActionType'
+            - type: 'null'
+          description: Filter by action type
+        from_date:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          description: Filter from date
+          title: From Date
+        to_date:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          description: Filter to date
+          title: To Date
+        format:
+          type: string
+          default: csv
+          description: 'Export format: csv or jsonl'
+          title: Format
+        max_records:
+          anyOf:
+            - type: integer
+              minimum: 1
+            - type: 'null'
+          description: Maximum records to export
+          title: Max Records
+      title: ExportJobRequest
+    ExportJobResponse:
+      type: object
+      description: Schema for export job creation response.
+      properties:
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+        status:
+          type: string
+          description: 'Job status: pending, processing, completed, failed, cancelled'
+          title: Status
+        message:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Status message
+          title: Message
+      required:
+        - job_id
+        - status
+      title: ExportJobResponse
+    ExportJobStatusResponse:
+      type: object
+      description: Schema for export job status response.
+      properties:
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+        status:
+          type: string
+          description: 'Job status: pending, processing, completed, failed, cancelled'
+          title: Status
+        progress:
+          type: integer
+          description: Progress percentage
+          maximum: 100
+          minimum: 0
+          title: Progress
+        total_records:
+          type: integer
+          description: Total records to export
+          minimum: 0
+          title: Total Records
+        processed_records:
+          type: integer
+          description: Records processed so far
+          minimum: 0
+          title: Processed Records
+        format:
+          type: string
+          description: 'Export format: csv or jsonl'
+          title: Format
+        file_size_bytes:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          description: File size in bytes (when completed)
+          title: File Size Bytes
+        error_message:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Error message (when failed)
+          title: Error Message
+        download_url:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Download URL (when completed)
+          title: Download Url
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        started_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Started At
+        completed_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Completed At
+        expires_at:
+          type: string
+          format: date-time
+          title: Expires At
+      required:
+        - created_at
+        - expires_at
+        - format
+        - job_id
+        - processed_records
+        - progress
+        - status
+        - total_records
+      title: ExportJobStatusResponse
+    FederationInfo:
+      type: object
+      description: Information about configured federation.
+      properties:
+        provider:
+          type: string
+          title: Provider
+        client_id:
+          type: string
+          title: Client Id
+        masked_secret:
+          type: string
+          title: Masked Secret
+        issuer:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Issuer
+        allowed_domains:
+          type: array
+          items:
+            type: string
+          title: Allowed Domains
+        configured_at:
+          type: string
+          format: date-time
+          title: Configured At
+        encryption_status:
+          type: string
+          enum:
+            - encrypted
+            - plaintext
+          title: Encryption Status
+      required:
+        - allowed_domains
+        - client_id
+        - configured_at
+        - encryption_status
+        - masked_secret
+        - provider
+      title: FederationInfo
+    FederationStatusResponse:
+      type: object
+      description: Federation configuration status for login page.
+      example:
+        has_global_oidc_config: false
+        has_multi_tenant_federation: false
+        has_single_tenant_federation: true
+        tenant_count: 1
+      properties:
+        has_single_tenant_federation:
+          type: boolean
+          title: Has Single Tenant Federation
+        has_multi_tenant_federation:
+          type: boolean
+          title: Has Multi Tenant Federation
+        has_global_oidc_config:
+          type: boolean
+          title: Has Global Oidc Config
+        tenant_count:
+          type: integer
+          title: Tenant Count
+      required:
+        - has_global_oidc_config
+        - has_multi_tenant_federation
+        - has_single_tenant_federation
+        - tenant_count
+      title: FederationStatusResponse
+    FeederLeader:
+      type: object
+      description: Feeder leader election status.
+      properties:
+        leader_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Leader Id
+        leader_ttl_seconds:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Leader Ttl Seconds
+        status:
+          type: string
+          default: UNKNOWN
+          title: Status
+      title: FeederLeader
     FilePublic:
       type: object
       properties:
@@ -11345,6 +19934,11 @@ components:
             - type: string
             - type: 'null'
           title: Transcription
+        token_count:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Token Count
       required:
         - id
         - mimetype
@@ -11357,10 +19951,10 @@ components:
         accepted_file_types:
           type: array
           items:
-            "$ref": "#/components/schemas/AcceptedFileType"
+            $ref: '#/components/schemas/AcceptedFileType'
           title: Accepted File Types
         limit:
-          "$ref": "#/components/schemas/Limit"
+          $ref: '#/components/schemas/Limit'
       required:
         - accepted_file_types
         - limit
@@ -11395,7 +19989,7 @@ components:
           type: string
           title: Message
         intric_error_code:
-          "$ref": "#/components/schemas/ErrorCodes"
+          $ref: '#/components/schemas/ErrorCodes'
       required:
         - intric_error_code
         - message
@@ -11406,12 +20000,12 @@ components:
         completion_models:
           type: array
           items:
-            "$ref": "#/components/schemas/CompletionModelPublic"
+            $ref: '#/components/schemas/CompletionModelPublic'
           title: Completion Models
         embedding_models:
           type: array
           items:
-            "$ref": "#/components/schemas/EmbeddingModelPublicLegacy"
+            $ref: '#/components/schemas/EmbeddingModelPublicLegacy'
           title: Embedding Models
       required:
         - completion_models
@@ -11454,7 +20048,8 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-          description: Custom description provided by the user. Cannot be null if
+          description: >-
+            Custom description provided by the user. Cannot be null if
             'description' of assistant is null.
           example: My custom AI assistant description
           title: User Description
@@ -11523,19 +20118,20 @@ components:
           title: Published
         insight_enabled:
           type: boolean
-          description: Whether insights are enabled for this group chat. If enabled,
-            users with appropriate permissions can see all sessions for this group
+          description: >-
+            Whether insights are enabled for this group chat. If enabled, users
+            with appropriate permissions can see all sessions for this group
             chat.
           title: Insight Enabled
         tools:
-          "$ref": "#/components/schemas/GroupChatTools"
+          $ref: '#/components/schemas/GroupChatTools'
         attachments:
           type: array
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Attachments
         allowed_attachments:
-          "$ref": "#/components/schemas/FileRestrictions"
+          $ref: '#/components/schemas/FileRestrictions'
         type:
           type: string
           const: group-chat
@@ -11543,7 +20139,7 @@ components:
         permissions:
           type: array
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         metadata_json:
           anyOf:
@@ -11575,7 +20171,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         created_at:
           type: string
@@ -11625,7 +20221,7 @@ components:
         assistants:
           type: array
           items:
-            "$ref": "#/components/schemas/GroupChatAssistantPublic"
+            $ref: '#/components/schemas/GroupChatAssistantPublic'
           title: Assistants
       required:
         - assistants
@@ -11647,7 +20243,7 @@ components:
           title: Space Id
         tools:
           anyOf:
-            - "$ref": "#/components/schemas/GroupChatUpdateTools"
+            - $ref: '#/components/schemas/GroupChatUpdateTools'
             - type: 'null'
           description: Tools available in the group chat.
         allow_mentions:
@@ -11666,8 +20262,9 @@ components:
           anyOf:
             - type: boolean
             - type: 'null'
-          description: Whether insights are enabled for this group chat. If enabled,
-            users with appropriate permissions can see all sessions for this group
+          description: >-
+            Whether insights are enabled for this group chat. If enabled, users
+            with appropriate permissions can see all sessions for this group
             chat.
           title: Insight Enabled
         metadata_json:
@@ -11684,7 +20281,7 @@ components:
         assistants:
           type: array
           items:
-            "$ref": "#/components/schemas/GroupChatAssistantUpdateSchema"
+            $ref: '#/components/schemas/GroupChatAssistantUpdateSchema'
           title: Assistants
       required:
         - assistants
@@ -11735,7 +20332,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         name:
           type: string
@@ -11757,14 +20354,19 @@ components:
           format: uuid
           title: Id
         embedding_model:
-          "$ref": "#/components/schemas/EmbeddingModelPublic"
+          $ref: '#/components/schemas/EmbeddingModelPublic'
+        space_id:
+          type: string
+          format: uuid
+          title: Space Id
         metadata:
-          "$ref": "#/components/schemas/GroupMetadata"
+          $ref: '#/components/schemas/GroupMetadata'
       required:
         - embedding_model
         - id
         - metadata
         - name
+        - space_id
       title: GroupPublicWithMetadata
     HTTPValidationError:
       type: object
@@ -11772,9 +20374,49 @@ components:
         detail:
           type: array
           items:
-            "$ref": "#/components/schemas/ValidationError"
+            $ref: '#/components/schemas/ValidationError'
           title: Detail
       title: HTTPValidationError
+    HealthThresholds:
+      type: object
+      description: Thresholds used for status decisions - helps explain status.
+      properties:
+        feeder_interval_seconds:
+          type: integer
+          title: Feeder Interval Seconds
+        watchdog_stale_threshold_seconds:
+          type: number
+          title: Watchdog Stale Threshold Seconds
+        heartbeat_ttl_expected_seconds:
+          type: integer
+          title: Heartbeat Ttl Expected Seconds
+      required:
+        - feeder_interval_seconds
+        - heartbeat_ttl_expected_seconds
+        - watchdog_stale_threshold_seconds
+      title: HealthThresholds
+    IconPublic:
+      type: object
+      properties:
+        created_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Created At
+        updated_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Updated At
+        id:
+          type: string
+          format: uuid
+          title: Id
+      required:
+        - id
+      title: IconPublic
     InfoBlobAddPublic:
       type: object
       properties:
@@ -11782,7 +20424,7 @@ components:
           type: string
           title: Text
         metadata:
-          "$ref": "#/components/schemas/InfoBlobMetadataUpsertPublic"
+          $ref: '#/components/schemas/InfoBlobMetadataUpsertPublic'
       required:
         - text
       title: InfoBlobAddPublic
@@ -11806,7 +20448,7 @@ components:
           format: uuid
           title: Id
         metadata:
-          "$ref": "#/components/schemas/InfoBlobMetadata"
+          $ref: '#/components/schemas/InfoBlobMetadata'
         group_id:
           anyOf:
             - type: string
@@ -11833,7 +20475,7 @@ components:
         formats:
           type: array
           items:
-            "$ref": "#/components/schemas/FormatLimit"
+            $ref: '#/components/schemas/FormatLimit'
           title: Formats
       required:
         - formats
@@ -11896,7 +20538,7 @@ components:
           format: uuid
           title: Id
         metadata:
-          "$ref": "#/components/schemas/InfoBlobMetadata"
+          $ref: '#/components/schemas/InfoBlobMetadata'
         group_id:
           anyOf:
             - type: string
@@ -11937,7 +20579,7 @@ components:
           format: uuid
           title: Id
         metadata:
-          "$ref": "#/components/schemas/InfoBlobMetadata"
+          $ref: '#/components/schemas/InfoBlobMetadata'
         group_id:
           anyOf:
             - type: string
@@ -11958,7 +20600,7 @@ components:
       type: object
       properties:
         metadata:
-          "$ref": "#/components/schemas/InfoBlobMetadataUpsertPublic"
+          $ref: '#/components/schemas/InfoBlobMetadataUpsertPublic'
       required:
         - metadata
       title: InfoBlobUpdatePublic
@@ -11968,16 +20610,33 @@ components:
         info_blobs:
           type: array
           items:
-            "$ref": "#/components/schemas/InfoBlobAddPublic"
+            $ref: '#/components/schemas/InfoBlobAddPublic'
           title: Info Blobs
       required:
         - info_blobs
       title: InfoBlobUpsertRequest
+    InitiateAuthResponse:
+      type: object
+      description: Response with IdP authorization URL.
+      example:
+        authorization_url: 'https://idp.example.com/authorize?client_id=abc123&...'
+        state: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+      properties:
+        authorization_url:
+          type: string
+          title: Authorization Url
+        state:
+          type: string
+          title: State
+      required:
+        - authorization_url
+        - state
+      title: InitiateAuthResponse
     InputField:
       type: object
       properties:
         type:
-          "$ref": "#/components/schemas/InputFieldType"
+          $ref: '#/components/schemas/InputFieldType'
         description:
           anyOf:
             - type: string
@@ -11992,12 +20651,12 @@ components:
         accepted_file_types:
           type: array
           items:
-            "$ref": "#/components/schemas/AcceptedFileType"
+            $ref: '#/components/schemas/AcceptedFileType'
           title: Accepted File Types
         limit:
-          "$ref": "#/components/schemas/Limit"
+          $ref: '#/components/schemas/Limit'
         type:
-          "$ref": "#/components/schemas/InputFieldType"
+          $ref: '#/components/schemas/InputFieldType'
         description:
           anyOf:
             - type: string
@@ -12031,7 +20690,7 @@ components:
           type: string
           title: Description
         integration_type:
-          "$ref": "#/components/schemas/IntegrationType"
+          $ref: '#/components/schemas/IntegrationType'
       required:
         - description
         - id
@@ -12044,6 +20703,27 @@ components:
         size:
           type: integer
           title: Size
+        last_sync_summary:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          title: Last Sync Summary
+        last_synced_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Last Synced At
+        sharepoint_subscription_expires_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          description: >-
+            When the SharePoint webhook subscription expires (only for
+            SharePoint integrations)
+          title: Sharepoint Subscription Expires At
       required:
         - size
       title: IntegrationKnowledgeMetaData
@@ -12057,6 +20737,11 @@ components:
         name:
           type: string
           title: Name
+        original_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Original Name
         url:
           type: string
           title: Url
@@ -12073,15 +20758,62 @@ components:
           format: uuid
           title: User Integration Id
         embedding_model:
-          "$ref": "#/components/schemas/EmbeddingModelPublicLegacy"
+          $ref: '#/components/schemas/EmbeddingModelPublicLegacy'
+        site_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Site Id
+        drive_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Drive Id
+        resource_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Resource Type
+        sharepoint_subscription_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Sharepoint Subscription Id
+        folder_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Folder Id
+        folder_path:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Folder Path
+        selected_item_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Selected Item Type
+        wrapper_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Wrapper Id
+        wrapper_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Wrapper Name
         permissions:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         metadata:
-          "$ref": "#/components/schemas/IntegrationKnowledgeMetaData"
+          $ref: '#/components/schemas/IntegrationKnowledgeMetaData'
         integration_type:
           type: string
           enum:
@@ -12090,42 +20822,65 @@ components:
           title: Integration Type
         task:
           type: string
-          description: |-
+          description: >-
             Create a collection of name/value pairs.
+
 
             Example enumeration:
 
+
             >>> class Color(Enum):
+
             ...     RED = 1
+
             ...     BLUE = 2
+
             ...     GREEN = 3
+
 
             Access them by:
 
+
             - attribute access::
 
+
             >>> Color.RED
+
             <Color.RED: 1>
+
 
             - value lookup:
 
+
             >>> Color(1)
+
             <Color.RED: 1>
+
 
             - name lookup:
 
+
             >>> Color['RED']
+
             <Color.RED: 1>
 
-            Enumerations can be iterated over, and know how many members they have:
+
+            Enumerations can be iterated over, and know how many members they
+            have:
+
 
             >>> len(Color)
+
             3
 
+
             >>> list(Color)
+
             [<Color.RED: 1>, <Color.BLUE: 2>, <Color.GREEN: 3>]
 
+
             Methods can be added to enumerations, and members can have their own
+
             attributes -- see the documentation for details.
           title: Enum
       required:
@@ -12146,7 +20901,7 @@ components:
         items:
           type: array
           items:
-            "$ref": "#/components/schemas/Integration"
+            $ref: '#/components/schemas/Integration'
           title: Items
         count:
           type: integer
@@ -12183,7 +20938,7 @@ components:
         items:
           type: array
           items:
-            "$ref": "#/components/schemas/IntegrationPreviewData"
+            $ref: '#/components/schemas/IntegrationPreviewData'
           title: Items
         count:
           type: integer
@@ -12224,9 +20979,9 @@ components:
             - type: 'null'
           title: Name
         status:
-          "$ref": "#/components/schemas/Status"
+          $ref: '#/components/schemas/Status'
         task:
-          "$ref": "#/components/schemas/Task"
+          $ref: '#/components/schemas/Task'
         result_location:
           anyOf:
             - type: string
@@ -12247,11 +21002,12 @@ components:
       type: object
       properties:
         groups:
-          "$ref": "#/components/schemas/PaginatedPermissions_CollectionPublic_"
+          $ref: '#/components/schemas/PaginatedPermissions_CollectionPublic_'
         websites:
-          "$ref": "#/components/schemas/PaginatedPermissions_WebsitePublic_"
+          $ref: '#/components/schemas/PaginatedPermissions_WebsitePublic_'
         integration_knowledge_list:
-          "$ref": "#/components/schemas/PaginatedPermissions_IntegrationKnowledgePublic_"
+          $ref: >-
+            #/components/schemas/PaginatedPermissions_IntegrationKnowledgePublic_
       required:
         - groups
         - integration_knowledge_list
@@ -12274,9 +21030,9 @@ components:
       type: object
       properties:
         info_blobs:
-          "$ref": "#/components/schemas/InfoBlobLimits"
+          $ref: '#/components/schemas/InfoBlobLimits'
         attachments:
-          "$ref": "#/components/schemas/AttachmentLimits"
+          $ref: '#/components/schemas/AttachmentLimits'
       required:
         - attachments
         - info_blobs
@@ -12328,29 +21084,29 @@ components:
           title: Answer
         completion_model:
           anyOf:
-            - "$ref": "#/components/schemas/CompletionModel"
+            - $ref: '#/components/schemas/CompletionModel'
             - type: 'null'
         references:
           type: array
           items:
-            "$ref": "#/components/schemas/InfoBlobPublicNoText"
+            $ref: '#/components/schemas/InfoBlobPublicNoText'
           title: References
         files:
           type: array
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Files
         tools:
-          "$ref": "#/components/schemas/UseTools"
+          $ref: '#/components/schemas/UseTools'
         generated_files:
           type: array
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Generated Files
         web_search_references:
           type: array
           items:
-            "$ref": "#/components/schemas/WebSearchResultPublic"
+            $ref: '#/components/schemas/WebSearchResultPublic'
           title: Web Search References
       required:
         - answer
@@ -12390,32 +21146,32 @@ components:
           title: Answer
         completion_model:
           anyOf:
-            - "$ref": "#/components/schemas/CompletionModel"
+            - $ref: '#/components/schemas/CompletionModel'
             - type: 'null'
         references:
           type: array
           items:
-            "$ref": "#/components/schemas/InfoBlobPublicNoText"
+            $ref: '#/components/schemas/InfoBlobPublicNoText'
           title: References
         files:
           type: array
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Files
         tools:
-          "$ref": "#/components/schemas/UseTools"
+          $ref: '#/components/schemas/UseTools'
         generated_files:
           type: array
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Generated Files
         web_search_references:
           type: array
           items:
-            "$ref": "#/components/schemas/WebSearchResultPublic"
+            $ref: '#/components/schemas/WebSearchResultPublic'
           title: Web Search References
         logging_details:
-          "$ref": "#/components/schemas/LoggingDetailsPublic"
+          $ref: '#/components/schemas/LoggingDetailsPublic'
       required:
         - answer
         - files
@@ -12432,23 +21188,70 @@ components:
         assistants:
           type: array
           items:
-            "$ref": "#/components/schemas/AssistantMetadata"
+            $ref: '#/components/schemas/AssistantMetadata'
           title: Assistants
         sessions:
           type: array
           items:
-            "$ref": "#/components/schemas/SessionMetadata"
+            $ref: '#/components/schemas/SessionMetadata'
           title: Sessions
         questions:
           type: array
           items:
-            "$ref": "#/components/schemas/QuestionMetadata"
+            $ref: '#/components/schemas/QuestionMetadata'
           title: Questions
       required:
         - assistants
         - questions
         - sessions
       title: MetadataStatistics
+    MigrationResult:
+      type: object
+      description: Result of a model migration operation.
+      properties:
+        success:
+          type: boolean
+          title: Success
+        migrated_count:
+          type: integer
+          title: Migrated Count
+        failed_count:
+          type: integer
+          title: Failed Count
+        details:
+          type: object
+          additionalProperties:
+            type: integer
+          title: Details
+        duration:
+          type: number
+          title: Duration
+        migration_id:
+          type: string
+          format: uuid
+          title: Migration Id
+        warnings:
+          type: array
+          default: []
+          items:
+            type: string
+          title: Warnings
+        auto_recalculated:
+          type: boolean
+          default: false
+          title: Auto Recalculated
+        requires_manual_recalculation:
+          type: boolean
+          default: false
+          title: Requires Manual Recalculation
+      required:
+        - details
+        - duration
+        - failed_count
+        - migrated_count
+        - migration_id
+        - success
+      title: MigrationResult
     ModelFamily:
       type: string
       enum:
@@ -12477,6 +21280,25 @@ components:
       required:
         - id
       title: ModelId
+    ModelInfo:
+      type: object
+      description: Information about the model used by the assistant.
+      properties:
+        name:
+          type: string
+          title: Name
+        token_limit:
+          type: integer
+          title: Token Limit
+        prompt_tokens:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Prompt Tokens
+      required:
+        - name
+        - token_limit
+      title: ModelInfo
     ModelKwargs:
       type: object
       properties:
@@ -12522,6 +21344,96 @@ components:
             - type: 'null'
           title: Top K
       title: ModelKwargs
+    ModelMigrationHistory:
+      type: object
+      description: Historical record of a model migration.
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        from_model_id:
+          type: string
+          format: uuid
+          title: From Model Id
+        from_model_name:
+          type: string
+          title: From Model Name
+        to_model_id:
+          type: string
+          format: uuid
+          title: To Model Id
+        to_model_name:
+          type: string
+          title: To Model Name
+        migrated_count:
+          type: integer
+          title: Migrated Count
+        status:
+          type: string
+          title: Status
+        initiated_by_id:
+          type: string
+          format: uuid
+          title: Initiated By Id
+        initiated_by_name:
+          type: string
+          title: Initiated By Name
+        started_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Started At
+        completed_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Completed At
+        duration:
+          anyOf:
+            - type: number
+            - type: 'null'
+          title: Duration
+        error_message:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Error Message
+      required:
+        - from_model_id
+        - from_model_name
+        - id
+        - initiated_by_id
+        - initiated_by_name
+        - migrated_count
+        - status
+        - to_model_id
+        - to_model_name
+      title: ModelMigrationHistory
+    ModelMigrationRequest:
+      type: object
+      description: Request to migrate usage from one model to another.
+      properties:
+        to_model_id:
+          type: string
+          format: uuid
+          title: To Model Id
+        entity_types:
+          anyOf:
+            - type: array
+              items:
+                type: string
+            - type: 'null'
+          title: Entity Types
+        confirm_migration:
+          type: boolean
+          default: false
+          title: Confirm Migration
+      required:
+        - to_model_id
+      title: ModelMigrationRequest
     ModelOrg:
       type: string
       enum:
@@ -12533,7 +21445,125 @@ components:
         - KBLab
         - Google
         - Berget
+        - GDM
       title: ModelOrg
+    ModelProviderCreate:
+      type: object
+      description: Request model for creating a model provider.
+      properties:
+        name:
+          type: string
+          description: User-defined name for this provider instance
+          title: Name
+        provider_type:
+          type: string
+          description: 'Provider type: openai, azure, or anthropic'
+          title: Provider Type
+        credentials:
+          type: object
+          additionalProperties: true
+          description: Provider credentials (will be encrypted)
+          title: Credentials
+        config:
+          type: object
+          additionalProperties: true
+          description: Additional configuration
+          title: Config
+        is_active:
+          type: boolean
+          default: true
+          description: Whether the provider is active
+          title: Is Active
+      required:
+        - credentials
+        - name
+        - provider_type
+      title: ModelProviderCreate
+    ModelProviderPublic:
+      type: object
+      description: Public response model for a model provider (without credentials).
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        tenant_id:
+          type: string
+          format: uuid
+          title: Tenant Id
+        name:
+          type: string
+          title: Name
+        provider_type:
+          type: string
+          title: Provider Type
+        config:
+          type: object
+          additionalProperties: true
+          title: Config
+        is_active:
+          type: boolean
+          title: Is Active
+        masked_api_key:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Masked Api Key
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      required:
+        - config
+        - created_at
+        - id
+        - is_active
+        - name
+        - provider_type
+        - tenant_id
+        - updated_at
+      title: ModelProviderPublic
+    ModelProviderUpdate:
+      type: object
+      description: Request model for updating a model provider.
+      properties:
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: User-defined name for this provider instance
+          title: Name
+        provider_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: 'Provider type: openai, azure, or anthropic'
+          title: Provider Type
+        credentials:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          description: Provider credentials (will be encrypted)
+          title: Credentials
+        config:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          description: Additional configuration
+          title: Config
+        is_active:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          description: Whether the provider is active
+          title: Is Active
+      title: ModelProviderUpdate
     ModelStability:
       type: string
       enum:
@@ -12560,6 +21590,12 @@ components:
             - type: 'null'
           description: Organization providing the model
           title: Model Org
+        model_provider:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Provider name for the model
+          title: Model Provider
         input_token_usage:
           type: integer
           description: Number of tokens used for input prompts
@@ -12585,6 +21621,143 @@ components:
         - request_count
         - total_token_usage
       title: ModelUsage
+    ModelUsageDetail:
+      type: object
+      description: Detailed information about a specific entity using a completion model.
+      properties:
+        entity_id:
+          type: string
+          format: uuid
+          title: Entity Id
+        entity_name:
+          type: string
+          title: Entity Name
+        entity_type:
+          type: string
+          title: Entity Type
+        space_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Space Id
+        space_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Space Name
+        owner_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Owner Id
+        owner_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Owner Name
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        last_used:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Last Used
+        usage_count:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Usage Count
+      required:
+        - created_at
+        - entity_id
+        - entity_name
+        - entity_type
+      title: ModelUsageDetail
+    ModelUsageStatistics:
+      type: object
+      description: Pre-aggregated usage statistics for a completion model.
+      properties:
+        model_id:
+          type: string
+          format: uuid
+          title: Model Id
+        total_usage:
+          type: integer
+          title: Total Usage
+        assistants_count:
+          type: integer
+          title: Assistants Count
+        apps_count:
+          type: integer
+          title: Apps Count
+        services_count:
+          type: integer
+          title: Services Count
+        questions_count:
+          type: integer
+          title: Questions Count
+        assistant_templates_count:
+          type: integer
+          title: Assistant Templates Count
+        app_templates_count:
+          type: integer
+          title: App Templates Count
+        spaces_count:
+          type: integer
+          title: Spaces Count
+        last_updated:
+          type: string
+          format: date-time
+          title: Last Updated
+      required:
+        - app_templates_count
+        - apps_count
+        - assistant_templates_count
+        - assistants_count
+        - last_updated
+        - model_id
+        - questions_count
+        - services_count
+        - spaces_count
+        - total_usage
+      title: ModelUsageStatistics
+    ModelUsageSummary:
+      type: object
+      description: Summary of usage for a single model.
+      properties:
+        model_id:
+          type: string
+          format: uuid
+          title: Model Id
+        model_name:
+          type: string
+          title: Model Name
+        model_nickname:
+          type: string
+          title: Model Nickname
+        is_enabled:
+          type: boolean
+          title: Is Enabled
+        total_usage:
+          type: integer
+          title: Total Usage
+        last_updated:
+          type: string
+          format: date-time
+          title: Last Updated
+      required:
+        - is_enabled
+        - last_updated
+        - model_id
+        - model_name
+        - model_nickname
+        - total_usage
+      title: ModelUsageSummary
     ModelsPresentation:
       type: object
       description: Presentation model for all types of AI models.
@@ -12592,17 +21765,17 @@ components:
         completion_models:
           type: array
           items:
-            "$ref": "#/components/schemas/CompletionModelSecurityStatus"
+            $ref: '#/components/schemas/CompletionModelSecurityStatus'
           title: Completion Models
         embedding_models:
           type: array
           items:
-            "$ref": "#/components/schemas/EmbeddingModelSecurityStatus"
+            $ref: '#/components/schemas/EmbeddingModelSecurityStatus'
           title: Embedding Models
         transcription_models:
           type: array
           items:
-            "$ref": "#/components/schemas/TranscriptionModelSecurityStatus"
+            $ref: '#/components/schemas/TranscriptionModelSecurityStatus'
           title: Transcription Models
       required:
         - completion_models
@@ -12614,7 +21787,7 @@ components:
       properties:
         name:
           anyOf:
-            - "$ref": "#/components/schemas/Modules"
+            - $ref: '#/components/schemas/Modules'
             - type: string
           title: Name
       required:
@@ -12625,7 +21798,7 @@ components:
       properties:
         name:
           anyOf:
-            - "$ref": "#/components/schemas/Modules"
+            - $ref: '#/components/schemas/Modules'
             - type: string
           title: Name
         created_at:
@@ -12652,10 +21825,73 @@ components:
       type: string
       description: Any change to these enums will result in database changes
       enum:
-        - eu_hosting
         - intric-applications
-        - SWE Models
       title: Modules
+    OIDCDebugToggleRequest:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Enable or disable OIDC debug logging
+          title: Enabled
+        duration_minutes:
+          anyOf:
+            - type: integer
+              maximum: 120
+              minimum: 1
+            - type: 'null'
+          default: 30
+          description: Duration in minutes before the toggle auto-expires (max 120)
+          title: Duration Minutes
+        reason:
+          anyOf:
+            - type: string
+              maxLength: 200
+            - type: 'null'
+          description: Optional note for audit trail
+          title: Reason
+      required:
+        - enabled
+      title: OIDCDebugToggleRequest
+    OIDCDebugToggleResponse:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          title: Enabled
+        enabled_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Enabled At
+        enabled_by:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Enabled By
+        expires_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Expires At
+        reason:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Reason
+        backend:
+          type: string
+          title: Backend
+      required:
+        - backend
+        - enabled
+        - enabled_at
+        - enabled_by
+        - expires_at
+        - reason
+      title: OIDCDebugToggleResponse
     OpenIdConnectLogin:
       type: object
       properties:
@@ -12670,7 +21906,6 @@ components:
           title: Redirect Uri
         client_id:
           type: string
-          default: intric
           title: Client Id
         grant_type:
           type: string
@@ -12681,13 +21916,23 @@ components:
           default: openid
           title: Scope
         nonce:
-          type: string
+          anyOf:
+            - type: string
+            - type: 'null'
           title: Nonce
       required:
+        - client_id
         - code
         - code_verifier
         - redirect_uri
       title: OpenIdConnectLogin
+    Outcome:
+      type: string
+      description: Indicate success or failure of audited action
+      enum:
+        - success
+        - failure
+      title: Outcome
     PaginatedPermissions_AppSparse_:
       type: object
       properties:
@@ -12695,13 +21940,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         items:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/AppSparse"
+            $ref: '#/components/schemas/AppSparse'
           title: Items
         count:
           type: integer
@@ -12711,7 +21956,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedPermissions[AppSparse]
+      title: 'PaginatedPermissions[AppSparse]'
     PaginatedPermissions_AssistantSparse_:
       type: object
       properties:
@@ -12719,13 +21964,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         items:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/AssistantSparse"
+            $ref: '#/components/schemas/AssistantSparse'
           title: Items
         count:
           type: integer
@@ -12735,7 +21980,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedPermissions[AssistantSparse]
+      title: 'PaginatedPermissions[AssistantSparse]'
     PaginatedPermissions_CollectionPublic_:
       type: object
       properties:
@@ -12743,13 +21988,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         items:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/CollectionPublic"
+            $ref: '#/components/schemas/CollectionPublic'
           title: Items
         count:
           type: integer
@@ -12759,7 +22004,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedPermissions[CollectionPublic]
+      title: 'PaginatedPermissions[CollectionPublic]'
     PaginatedPermissions_GroupChatSparse_:
       type: object
       properties:
@@ -12767,13 +22012,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         items:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/GroupChatSparse"
+            $ref: '#/components/schemas/GroupChatSparse'
           title: Items
         count:
           type: integer
@@ -12783,7 +22028,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedPermissions[GroupChatSparse]
+      title: 'PaginatedPermissions[GroupChatSparse]'
     PaginatedPermissions_IntegrationKnowledgePublic_:
       type: object
       properties:
@@ -12791,13 +22036,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         items:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/IntegrationKnowledgePublic"
+            $ref: '#/components/schemas/IntegrationKnowledgePublic'
           title: Items
         count:
           type: integer
@@ -12807,7 +22052,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedPermissions[IntegrationKnowledgePublic]
+      title: 'PaginatedPermissions[IntegrationKnowledgePublic]'
     PaginatedPermissions_ServiceSparse_:
       type: object
       properties:
@@ -12815,13 +22060,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         items:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/ServiceSparse"
+            $ref: '#/components/schemas/ServiceSparse'
           title: Items
         count:
           type: integer
@@ -12831,7 +22076,31 @@ components:
       required:
         - count
         - items
-      title: PaginatedPermissions[ServiceSparse]
+      title: 'PaginatedPermissions[ServiceSparse]'
+    PaginatedPermissions_SpaceGroupMember_:
+      type: object
+      properties:
+        permissions:
+          type: array
+          default: []
+          items:
+            $ref: '#/components/schemas/ResourcePermission'
+          title: Permissions
+        items:
+          type: array
+          description: List of items returned in the response
+          items:
+            $ref: '#/components/schemas/SpaceGroupMember'
+          title: Items
+        count:
+          type: integer
+          description: Number of items returned in the response
+          readOnly: true
+          title: Count
+      required:
+        - count
+        - items
+      title: 'PaginatedPermissions[SpaceGroupMember]'
     PaginatedPermissions_SpaceMember_:
       type: object
       properties:
@@ -12839,13 +22108,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         items:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/SpaceMember"
+            $ref: '#/components/schemas/SpaceMember'
           title: Items
         count:
           type: integer
@@ -12855,7 +22124,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedPermissions[SpaceMember]
+      title: 'PaginatedPermissions[SpaceMember]'
     PaginatedPermissions_WebsitePublic_:
       type: object
       properties:
@@ -12863,13 +22132,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         items:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/WebsitePublic"
+            $ref: '#/components/schemas/WebsitePublic'
           title: Items
         count:
           type: integer
@@ -12879,7 +22148,37 @@ components:
       required:
         - count
         - items
-      title: PaginatedPermissions[WebsitePublic]
+      title: 'PaginatedPermissions[WebsitePublic]'
+    PaginatedResponse:
+      type: object
+      description: Generic paginated response with cursor-based pagination.
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ModelUsageDetail'
+          title: Items
+        total:
+          type: integer
+          title: Total
+        has_more:
+          type: boolean
+          title: Has More
+        next_cursor:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Next Cursor
+        prev_cursor:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Prev Cursor
+      required:
+        - has_more
+        - items
+        - total
+      title: PaginatedResponse
     PaginatedResponse_AllowedOriginInDB_:
       type: object
       properties:
@@ -12887,7 +22186,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/AllowedOriginInDB"
+            $ref: '#/components/schemas/AllowedOriginInDB'
           title: Items
         count:
           type: integer
@@ -12897,7 +22196,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[AllowedOriginInDB]
+      title: 'PaginatedResponse[AllowedOriginInDB]'
     PaginatedResponse_AllowedOriginPublic_:
       type: object
       properties:
@@ -12905,7 +22204,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/AllowedOriginPublic"
+            $ref: '#/components/schemas/AllowedOriginPublic'
           title: Items
         count:
           type: integer
@@ -12915,7 +22214,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[AllowedOriginPublic]
+      title: 'PaginatedResponse[AllowedOriginPublic]'
     PaginatedResponse_AppRunSparse_:
       type: object
       properties:
@@ -12923,7 +22222,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/AppRunSparse"
+            $ref: '#/components/schemas/AppRunSparse'
           title: Items
         count:
           type: integer
@@ -12933,7 +22232,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[AppRunSparse]
+      title: 'PaginatedResponse[AppRunSparse]'
     PaginatedResponse_AssistantPublic_:
       type: object
       properties:
@@ -12941,7 +22240,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/AssistantPublic"
+            $ref: '#/components/schemas/AssistantPublic'
           title: Items
         count:
           type: integer
@@ -12951,7 +22250,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[AssistantPublic]
+      title: 'PaginatedResponse[AssistantPublic]'
     PaginatedResponse_CompletionModelPublic_:
       type: object
       properties:
@@ -12959,7 +22258,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/CompletionModelPublic"
+            $ref: '#/components/schemas/CompletionModelPublic'
           title: Items
         count:
           type: integer
@@ -12969,7 +22268,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[CompletionModelPublic]
+      title: 'PaginatedResponse[CompletionModelPublic]'
     PaginatedResponse_CrawlRunPublic_:
       type: object
       properties:
@@ -12977,7 +22276,8 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/intric__websites__presentation__website_models__CrawlRunPublic"
+            $ref: >-
+              #/components/schemas/intric__websites__presentation__website_models__CrawlRunPublic
           title: Items
         count:
           type: integer
@@ -12987,7 +22287,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[CrawlRunPublic]
+      title: 'PaginatedResponse[CrawlRunPublic]'
     PaginatedResponse_EmbeddingModelLegacy_:
       type: object
       properties:
@@ -12995,7 +22295,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/EmbeddingModelLegacy"
+            $ref: '#/components/schemas/EmbeddingModelLegacy'
           title: Items
         count:
           type: integer
@@ -13005,7 +22305,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[EmbeddingModelLegacy]
+      title: 'PaginatedResponse[EmbeddingModelLegacy]'
     PaginatedResponse_EmbeddingModelPublic_:
       type: object
       properties:
@@ -13013,7 +22313,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/EmbeddingModelPublic"
+            $ref: '#/components/schemas/EmbeddingModelPublic'
           title: Items
         count:
           type: integer
@@ -13023,7 +22323,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[EmbeddingModelPublic]
+      title: 'PaginatedResponse[EmbeddingModelPublic]'
     PaginatedResponse_FilePublic_:
       type: object
       properties:
@@ -13031,7 +22331,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Items
         count:
           type: integer
@@ -13041,7 +22341,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[FilePublic]
+      title: 'PaginatedResponse[FilePublic]'
     PaginatedResponse_GroupPublicWithMetadata_:
       type: object
       properties:
@@ -13049,7 +22349,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/GroupPublicWithMetadata"
+            $ref: '#/components/schemas/GroupPublicWithMetadata'
           title: Items
         count:
           type: integer
@@ -13059,7 +22359,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[GroupPublicWithMetadata]
+      title: 'PaginatedResponse[GroupPublicWithMetadata]'
     PaginatedResponse_InfoBlobPublicNoText_:
       type: object
       properties:
@@ -13067,7 +22367,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/InfoBlobPublicNoText"
+            $ref: '#/components/schemas/InfoBlobPublicNoText'
           title: Items
         count:
           type: integer
@@ -13077,7 +22377,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[InfoBlobPublicNoText]
+      title: 'PaginatedResponse[InfoBlobPublicNoText]'
     PaginatedResponse_InfoBlobPublic_:
       type: object
       properties:
@@ -13085,7 +22385,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/InfoBlobPublic"
+            $ref: '#/components/schemas/InfoBlobPublic'
           title: Items
         count:
           type: integer
@@ -13095,7 +22395,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[InfoBlobPublic]
+      title: 'PaginatedResponse[InfoBlobPublic]'
     PaginatedResponse_JobPublic_:
       type: object
       properties:
@@ -13103,7 +22403,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/JobPublic"
+            $ref: '#/components/schemas/JobPublic'
           title: Items
         count:
           type: integer
@@ -13113,7 +22413,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[JobPublic]
+      title: 'PaginatedResponse[JobPublic]'
     PaginatedResponse_Message_:
       type: object
       properties:
@@ -13121,7 +22421,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/Message"
+            $ref: '#/components/schemas/Message'
           title: Items
         count:
           type: integer
@@ -13131,7 +22431,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[Message]
+      title: 'PaginatedResponse[Message]'
     PaginatedResponse_ModuleInDB_:
       type: object
       properties:
@@ -13139,7 +22439,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/ModuleInDB"
+            $ref: '#/components/schemas/ModuleInDB'
           title: Items
         count:
           type: integer
@@ -13149,7 +22449,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[ModuleInDB]
+      title: 'PaginatedResponse[ModuleInDB]'
     PaginatedResponse_PredefinedRolePublic_:
       type: object
       properties:
@@ -13157,7 +22457,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/PredefinedRolePublic"
+            $ref: '#/components/schemas/PredefinedRolePublic'
           title: Items
         count:
           type: integer
@@ -13167,7 +22467,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[PredefinedRolePublic]
+      title: 'PaginatedResponse[PredefinedRolePublic]'
     PaginatedResponse_PromptSparse_:
       type: object
       properties:
@@ -13175,7 +22475,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/PromptSparse"
+            $ref: '#/components/schemas/PromptSparse'
           title: Items
         count:
           type: integer
@@ -13185,7 +22485,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[PromptSparse]
+      title: 'PaginatedResponse[PromptSparse]'
     PaginatedResponse_RolePublic_:
       type: object
       properties:
@@ -13193,7 +22493,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/RolePublic"
+            $ref: '#/components/schemas/RolePublic'
           title: Items
         count:
           type: integer
@@ -13203,7 +22503,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[RolePublic]
+      title: 'PaginatedResponse[RolePublic]'
     PaginatedResponse_SemanticSearchResponse_:
       type: object
       properties:
@@ -13211,7 +22511,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/SemanticSearchResponse"
+            $ref: '#/components/schemas/SemanticSearchResponse'
           title: Items
         count:
           type: integer
@@ -13221,7 +22521,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[SemanticSearchResponse]
+      title: 'PaginatedResponse[SemanticSearchResponse]'
     PaginatedResponse_ServicePublicWithUser_:
       type: object
       properties:
@@ -13229,7 +22529,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/ServicePublicWithUser"
+            $ref: '#/components/schemas/ServicePublicWithUser'
           title: Items
         count:
           type: integer
@@ -13239,7 +22539,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[ServicePublicWithUser]
+      title: 'PaginatedResponse[ServicePublicWithUser]'
     PaginatedResponse_ServiceRun_:
       type: object
       properties:
@@ -13247,7 +22547,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/ServiceRun"
+            $ref: '#/components/schemas/ServiceRun'
           title: Items
         count:
           type: integer
@@ -13257,7 +22557,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[ServiceRun]
+      title: 'PaginatedResponse[ServiceRun]'
     PaginatedResponse_SpaceDashboard_:
       type: object
       properties:
@@ -13265,7 +22565,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/SpaceDashboard"
+            $ref: '#/components/schemas/SpaceDashboard'
           title: Items
         count:
           type: integer
@@ -13275,7 +22575,25 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[SpaceDashboard]
+      title: 'PaginatedResponse[SpaceDashboard]'
+    PaginatedResponse_SpaceGroupMember_:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of items returned in the response
+          items:
+            $ref: '#/components/schemas/SpaceGroupMember'
+          title: Items
+        count:
+          type: integer
+          description: Number of items returned in the response
+          readOnly: true
+          title: Count
+      required:
+        - count
+        - items
+      title: 'PaginatedResponse[SpaceGroupMember]'
     PaginatedResponse_SpaceSparse_:
       type: object
       properties:
@@ -13283,7 +22601,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/SpaceSparse"
+            $ref: '#/components/schemas/SpaceSparse'
           title: Items
         count:
           type: integer
@@ -13293,15 +22611,15 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[SpaceSparse]
-    PaginatedResponse_TenantInDB_:
+      title: 'PaginatedResponse[SpaceSparse]'
+    PaginatedResponse_TenantWithMaskedCredentials_:
       type: object
       properties:
         items:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/TenantInDB"
+            $ref: '#/components/schemas/TenantWithMaskedCredentials'
           title: Items
         count:
           type: integer
@@ -13311,7 +22629,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[TenantInDB]
+      title: 'PaginatedResponse[TenantWithMaskedCredentials]'
     PaginatedResponse_TranscriptionModelPublic_:
       type: object
       properties:
@@ -13319,7 +22637,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/TranscriptionModelPublic"
+            $ref: '#/components/schemas/TranscriptionModelPublic'
           title: Items
         count:
           type: integer
@@ -13329,25 +22647,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[TranscriptionModelPublic]
-    PaginatedResponse_UserAdminView_:
-      type: object
-      properties:
-        items:
-          type: array
-          description: List of items returned in the response
-          items:
-            "$ref": "#/components/schemas/UserAdminView"
-          title: Items
-        count:
-          type: integer
-          description: Number of items returned in the response
-          readOnly: true
-          title: Count
-      required:
-        - count
-        - items
-      title: PaginatedResponse[UserAdminView]
+      title: 'PaginatedResponse[TranscriptionModelPublic]'
     PaginatedResponse_UserGroupPublic_:
       type: object
       properties:
@@ -13355,7 +22655,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/UserGroupPublic"
+            $ref: '#/components/schemas/UserGroupPublic'
           title: Items
         count:
           type: integer
@@ -13365,7 +22665,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[UserGroupPublic]
+      title: 'PaginatedResponse[UserGroupPublic]'
     PaginatedResponse_UserInDB_:
       type: object
       properties:
@@ -13373,7 +22673,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/UserInDB"
+            $ref: '#/components/schemas/UserInDB'
           title: Items
         count:
           type: integer
@@ -13383,7 +22683,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[UserInDB]
+      title: 'PaginatedResponse[UserInDB]'
     PaginatedResponse_WebsitePublic_:
       type: object
       properties:
@@ -13391,7 +22691,7 @@ components:
           type: array
           description: List of items returned in the response
           items:
-            "$ref": "#/components/schemas/WebsitePublic"
+            $ref: '#/components/schemas/WebsitePublic'
           title: Items
         count:
           type: integer
@@ -13401,7 +22701,7 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[WebsitePublic]
+      title: 'PaginatedResponse[WebsitePublic]'
     PaginatedResponse_str_:
       type: object
       properties:
@@ -13419,7 +22719,144 @@ components:
       required:
         - count
         - items
-      title: PaginatedResponse[str]
+      title: 'PaginatedResponse[str]'
+    PaginatedSyncLogList:
+      type: object
+      description: Paginated sync logs response with metadata.
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SyncLog'
+          title: Items
+        total_count:
+          type: integer
+          title: Total Count
+        page_size:
+          type: integer
+          title: Page Size
+        offset:
+          type: integer
+          title: Offset
+        count:
+          type: integer
+          readOnly: true
+          title: Count
+        current_page:
+          type: integer
+          description: Calculate the current page number (1-indexed).
+          readOnly: true
+          title: Current Page
+        total_pages:
+          type: integer
+          description: Calculate the total number of pages.
+          readOnly: true
+          title: Total Pages
+        has_next:
+          type: boolean
+          description: Check if there is a next page.
+          readOnly: true
+          title: Has Next
+        has_previous:
+          type: boolean
+          description: Check if there is a previous page.
+          readOnly: true
+          title: Has Previous
+      required:
+        - count
+        - current_page
+        - has_next
+        - has_previous
+        - items
+        - offset
+        - page_size
+        - total_count
+        - total_pages
+      title: PaginatedSyncLogList
+    PaginatedUsersResponse_UserAdminView_:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of users for the current page
+          examples:
+            - []
+          items:
+            $ref: '#/components/schemas/UserAdminView'
+          title: Items
+        metadata:
+          $ref: '#/components/schemas/PaginationMetadata'
+          description: Pagination metadata for navigation
+      required:
+        - items
+        - metadata
+      title: 'PaginatedUsersResponse[UserAdminView]'
+    PaginationMetadata:
+      type: object
+      description: >-
+        Pagination metadata for frontend navigation.
+
+
+        Provides all information needed to build pagination UI (page numbers,
+        next/previous buttons).
+
+        Includes counts by state for tab display.
+      properties:
+        page:
+          type: integer
+          description: Current page number (1-based)
+          examples:
+            - 1
+          title: Page
+        page_size:
+          type: integer
+          description: Number of items per page
+          examples:
+            - 100
+          title: Page Size
+        total_count:
+          type: integer
+          description: Total number of items across all pages
+          examples:
+            - 543
+          title: Total Count
+        total_pages:
+          type: integer
+          description: Total number of pages (calculated from total_count and page_size)
+          examples:
+            - 6
+          title: Total Pages
+        has_next:
+          type: boolean
+          description: Whether there is a next page available
+          examples:
+            - true
+          title: Has Next
+        has_previous:
+          type: boolean
+          description: Whether there is a previous page available
+          examples:
+            - false
+          title: Has Previous
+        counts:
+          anyOf:
+            - type: object
+              additionalProperties:
+                type: integer
+            - type: 'null'
+          description: 'Optional counts by state (active, inactive) for tab display'
+          examples:
+            - active: 2828
+              inactive: 3
+          title: Counts
+      required:
+        - has_next
+        - has_previous
+        - page
+        - page_size
+        - total_count
+        - total_pages
+      title: PaginationMetadata
     PartialAssistantUpdatePublic:
       type: object
       properties:
@@ -13430,7 +22867,7 @@ components:
           title: Name
         completion_model_kwargs:
           anyOf:
-            - "$ref": "#/components/schemas/ModelKwargs"
+            - $ref: '#/components/schemas/ModelKwargs'
             - type: 'null'
           deprecated: true
           description: This field is deprecated and will be ignored
@@ -13449,13 +22886,13 @@ components:
           title: Space Id
         prompt:
           anyOf:
-            - "$ref": "#/components/schemas/PromptCreate"
+            - $ref: '#/components/schemas/PromptCreate'
             - type: 'null'
         groups:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/ModelId"
+                $ref: '#/components/schemas/ModelId'
             - type: 'null'
           deprecated: true
           description: This field is deprecated and will be ignored
@@ -13464,7 +22901,7 @@ components:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/ModelId"
+                $ref: '#/components/schemas/ModelId'
             - type: 'null'
           deprecated: true
           description: This field is deprecated and will be ignored
@@ -13473,20 +22910,20 @@ components:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/ModelId"
+                $ref: '#/components/schemas/ModelId'
             - type: 'null'
           deprecated: true
           description: This field is deprecated and will be ignored
           title: Integration Knowledge List
         guardrail:
           anyOf:
-            - "$ref": "#/components/schemas/AssistantGuard"
+            - $ref: '#/components/schemas/AssistantGuard'
             - type: 'null'
           deprecated: true
           description: This field is deprecated and will be ignored
         completion_model:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
           deprecated: true
           description: This field is deprecated and will be ignored
@@ -13494,14 +22931,15 @@ components:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/ModelId"
+                $ref: '#/components/schemas/ModelId'
             - type: 'null'
           title: Attachments
         description:
           anyOf:
             - type: string
             - type: 'null'
-          description: A description of the assitant that will be used as default
+          description: >-
+            A description of the assitant that will be used as default
             description in GroupChatAssistantPublic
           example: This is a helpful AI assistant
           title: Description
@@ -13509,8 +22947,10 @@ components:
           anyOf:
             - type: boolean
             - type: 'null'
-          description: Whether insights are enabled for this assistant. If enabled,
-            users with appropriate permissions can see all sessions for this assistant.
+          description: >-
+            Whether insights are enabled for this assistant. If enabled, users
+            with appropriate permissions can see all sessions for this
+            assistant.
           title: Insight Enabled
         data_retention_days:
           anyOf:
@@ -13524,17 +22964,194 @@ components:
             - type: 'null'
           description: Metadata for the assistant
           title: Metadata Json
+        icon_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Icon ID referencing an uploaded icon. Set to null to remove.
+          title: Icon Id
       title: PartialAssistantUpdatePublic
+    PartialCompletionModelUpdate:
+      type: object
+      properties:
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Name
+        nickname:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Nickname
+        family:
+          anyOf:
+            - $ref: '#/components/schemas/ModelFamily'
+            - type: string
+            - type: 'null'
+          title: Family
+        token_limit:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Token Limit
+        is_deprecated:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          title: Is Deprecated
+        nr_billion_parameters:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Nr Billion Parameters
+        hf_link:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Hf Link
+        stability:
+          anyOf:
+            - $ref: '#/components/schemas/ModelStability'
+            - type: string
+            - type: 'null'
+          title: Stability
+        hosting:
+          anyOf:
+            - $ref: '#/components/schemas/ModelHostingLocation'
+            - type: string
+            - type: 'null'
+          title: Hosting
+        open_source:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          title: Open Source
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Description
+        deployment_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Deployment Name
+        org:
+          anyOf:
+            - $ref: '#/components/schemas/ModelOrg'
+            - type: string
+            - type: 'null'
+          title: Org
+        vision:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          title: Vision
+        reasoning:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          title: Reasoning
+        base_url:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Base Url
+        litellm_model_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Litellm Model Name
+        id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Id
+      title: PartialCompletionModelUpdate
+    PartialEmbeddingModelUpdate:
+      type: object
+      properties:
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Name
+        family:
+          anyOf:
+            - $ref: '#/components/schemas/EmbeddingModelFamily'
+            - type: 'null'
+        is_deprecated:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          title: Is Deprecated
+        open_source:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          title: Open Source
+        dimensions:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Dimensions
+        max_input:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Max Input
+        max_batch_size:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Max Batch Size
+        hf_link:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Hf Link
+        stability:
+          anyOf:
+            - $ref: '#/components/schemas/ModelStability'
+            - type: 'null'
+        hosting:
+          anyOf:
+            - $ref: '#/components/schemas/ModelHostingLocation'
+            - type: 'null'
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Description
+        org:
+          anyOf:
+            - $ref: '#/components/schemas/ModelOrg'
+            - type: 'null'
+        litellm_model_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Litellm Model Name
+        id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Id
+      title: PartialEmbeddingModelUpdate
     PartialPropUserUpdate:
       type: object
       properties:
         predefined_role:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
         state:
           anyOf:
-            - "$ref": "#/components/schemas/UserState"
+            - $ref: '#/components/schemas/UserState'
             - type: 'null'
       title: PartialPropUserUpdate
     PartialServiceUpdatePublic:
@@ -13567,18 +23184,18 @@ components:
           title: Prompt
         completion_model_kwargs:
           anyOf:
-            - "$ref": "#/components/schemas/ModelKwargs"
+            - $ref: '#/components/schemas/ModelKwargs'
             - type: 'null'
         groups:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/ModelId"
+                $ref: '#/components/schemas/ModelId'
             - type: 'null'
           title: Groups
         completion_model:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
       title: PartialServiceUpdatePublic
     PartialUpdateSpaceRequest:
@@ -13598,32 +23215,72 @@ components:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/ModelId"
+                $ref: '#/components/schemas/ModelId'
             - type: 'null'
           title: Embedding Models
         completion_models:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/ModelId"
+                $ref: '#/components/schemas/ModelId'
             - type: 'null'
           title: Completion Models
         transcription_models:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/ModelId"
+                $ref: '#/components/schemas/ModelId'
             - type: 'null'
           title: Transcription Models
         security_classification:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
-          description: ID of the security classification to apply to this space. Set
-            to null to remove the security classification. Omit to keep the current
+          description: >-
+            ID of the security classification to apply to this space. Set to
+            null to remove the security classification. Omit to keep the current
             security classification unchanged.
           title: Security Classification
+        icon_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Icon ID referencing an uploaded icon. Set to null to remove.
+          title: Icon Id
+        data_retention_days:
+          anyOf:
+            - type: integer
+              ge: 1
+              le: 2555
+            - type: 'null'
+          description: >-
+            Number of days to retain conversation history for this space.
+            Applies to all assistants and apps in the space that don't have
+            their own retention policy. Set to null to disable space-level
+            retention. Omit to keep the current retention policy unchanged.
+            Valid range: 1-2555 days (1 day to 7 years).
+          title: Data Retention Days
       title: PartialUpdateSpaceRequest
+    PendingQueueSummary:
+      type: object
+      description: Pending crawl queue summary.
+      properties:
+        total:
+          type: integer
+          default: 0
+          title: Total
+        tenant_count:
+          type: integer
+          default: 0
+          title: Tenant Count
+        top_tenants:
+          type: object
+          additionalProperties:
+            type: integer
+          default: {}
+          title: Top Tenants
+      title: PendingQueueSummary
     Permission:
       type: string
       enum:
@@ -13643,7 +23300,7 @@ components:
       type: object
       properties:
         name:
-          "$ref": "#/components/schemas/Permission"
+          $ref: '#/components/schemas/Permission'
         description:
           type: string
           title: Description
@@ -13672,7 +23329,7 @@ components:
         permissions:
           type: array
           items:
-            "$ref": "#/components/schemas/Permission"
+            $ref: '#/components/schemas/Permission'
           title: Permissions
         id:
           type: string
@@ -13704,7 +23361,7 @@ components:
         permissions:
           type: array
           items:
-            "$ref": "#/components/schemas/Permission"
+            $ref: '#/components/schemas/Permission'
           title: Permissions
         id:
           type: string
@@ -13748,7 +23405,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         created_at:
           anyOf:
@@ -13777,7 +23434,7 @@ components:
             - type: 'null'
           title: Is Selected
         user:
-          "$ref": "#/components/schemas/UserSparse"
+          $ref: '#/components/schemas/UserSparse'
         text:
           type: string
           title: Text
@@ -13815,7 +23472,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         created_at:
           anyOf:
@@ -13842,7 +23499,7 @@ components:
           type: boolean
           title: Is Selected
         user:
-          "$ref": "#/components/schemas/UserSparse"
+          $ref: '#/components/schemas/UserSparse'
       required:
         - id
         - is_selected
@@ -13862,11 +23519,11 @@ components:
       properties:
         predefined_role:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
         state:
           anyOf:
-            - "$ref": "#/components/schemas/UserState"
+            - $ref: '#/components/schemas/UserState'
             - type: 'null'
         email:
           type: string
@@ -13914,6 +23571,73 @@ components:
         - insight_view
         - insight_toggle
       title: ResourcePermission
+    RetentionPolicyResponse:
+      type: object
+      description: >-
+        Schema for audit log retention policy response.
+
+
+        Note: Conversation retention is configured at the Assistant, App, or
+        Space level,
+
+        not at the tenant level, to prevent accidental data loss.
+      properties:
+        tenant_id:
+          type: string
+          format: uuid
+          title: Tenant Id
+        retention_days:
+          type: integer
+          description: 'Days to retain audit logs (1-2555). Recommended: 90+'
+          maximum: 2555
+          minimum: 1
+          title: Retention Days
+        last_purge_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Last Purge At
+        purge_count:
+          type: integer
+          title: Purge Count
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      required:
+        - created_at
+        - purge_count
+        - retention_days
+        - tenant_id
+        - updated_at
+      title: RetentionPolicyResponse
+    RetentionPolicyUpdateRequest:
+      type: object
+      description: >-
+        Schema for updating audit log retention policy.
+
+
+        Note: Conversation retention is configured at the Assistant, App, or
+        Space level,
+
+        not at the tenant level, to prevent accidental data loss.
+      properties:
+        retention_days:
+          type: integer
+          description: >-
+            Days to retain audit logs (1 day minimum, 2555 days/7 years
+            maximum). Recommended: 90+ days for compliance
+          maximum: 2555
+          minimum: 1
+          title: Retention Days
+      required:
+        - retention_days
+      title: RetentionPolicyUpdateRequest
     RoleCreateRequest:
       type: object
       properties:
@@ -13923,7 +23647,7 @@ components:
         permissions:
           type: array
           items:
-            "$ref": "#/components/schemas/Permission"
+            $ref: '#/components/schemas/Permission'
           title: Permissions
       required:
         - name
@@ -13954,7 +23678,7 @@ components:
         permissions:
           type: array
           items:
-            "$ref": "#/components/schemas/Permission"
+            $ref: '#/components/schemas/Permission'
           title: Permissions
         tenant_id:
           type: string
@@ -13991,7 +23715,7 @@ components:
         permissions:
           type: array
           items:
-            "$ref": "#/components/schemas/Permission"
+            $ref: '#/components/schemas/Permission'
           title: Permissions
       required:
         - id
@@ -14010,7 +23734,7 @@ components:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/Permission"
+                $ref: '#/components/schemas/Permission'
             - type: 'null'
           title: Permissions
       title: RoleUpdateRequest
@@ -14018,9 +23742,9 @@ components:
       type: object
       properties:
         roles:
-          "$ref": "#/components/schemas/PaginatedResponse_RolePublic_"
+          $ref: '#/components/schemas/PaginatedResponse_RolePublic_'
         predefined_roles:
-          "$ref": "#/components/schemas/PaginatedResponse_PredefinedRolePublic_"
+          $ref: '#/components/schemas/PaginatedResponse_PredefinedRolePublic_'
       required:
         - predefined_roles
         - roles
@@ -14032,7 +23756,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ModelId"
+            $ref: '#/components/schemas/ModelId'
           title: Files
         text:
           anyOf:
@@ -14050,8 +23774,9 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ModelId"
-          maxItems: 1
+            type: string
+            format: uuid
+          maxItems: 20
           title: Files
       required:
         - input
@@ -14073,7 +23798,7 @@ components:
         set_lowest_security:
           type: boolean
           default: true
-          description: Set lowest security level (0) if true, highest level if false
+          description: 'Set lowest security level (0) if true, highest level if false'
           title: Set Lowest Security
       required:
         - name
@@ -14085,7 +23810,7 @@ components:
           type: array
           description: Security classification IDs
           items:
-            "$ref": "#/components/schemas/ModelId"
+            $ref: '#/components/schemas/ModelId'
           title: Security Classifications
       required:
         - security_classifications
@@ -14136,7 +23861,7 @@ components:
         security_classifications:
           type: array
           items:
-            "$ref": "#/components/schemas/SecurityClassificationPublic"
+            $ref: '#/components/schemas/SecurityClassificationPublic'
           title: Security Classifications
       required:
         - security_classifications
@@ -14144,7 +23869,8 @@ components:
       title: SecurityClassificationResponse
     SecurityClassificationSingleUpdate:
       type: object
-      description: Model for updating an existing security classification's name and
+      description: >-
+        Model for updating an existing security classification's name and
         description only.
       properties:
         name:
@@ -14165,7 +23891,7 @@ components:
         security_classifications:
           type: array
           items:
-            "$ref": "#/components/schemas/SecurityClassificationPublic"
+            $ref: '#/components/schemas/SecurityClassificationPublic'
           title: Security Classifications
       required:
         - security_classifications
@@ -14176,16 +23902,16 @@ components:
       properties:
         enabled:
           type: boolean
-          description: Whether security classifications should be enabled for the
-            tenant
+          description: Whether security classifications should be enabled for the tenant
           title: Enabled
       required:
         - enabled
       title: SecurityEnableRequest
     SecurityEnableResponse:
       type: object
-      description: Response after enabling or disabling security classifications for
-        a tenant.
+      description: >-
+        Response after enabling or disabling security classifications for a
+        tenant.
       properties:
         security_enabled:
           type: boolean
@@ -14208,9 +23934,10 @@ components:
           anyOf:
             - type: integer
             - type: 'null'
-          description: Experimental feature that tries to limit the amount of chunks
-            to only the relevant ones, based on the score. Set to null (or omit completely)
-            to not use this feature
+          description: >-
+            Experimental feature that tries to limit the amount of chunks to
+            only the relevant ones, based on the score. Set to null (or omit
+            completely) to not use this feature
           title: Autocut Cutoff
       required:
         - search_string
@@ -14248,6 +23975,62 @@ components:
         - text
         - updated_at
       title: SemanticSearchResponse
+    ServiceAccountAuthCallback:
+      type: object
+      description: Request model for service account OAuth callback.
+      properties:
+        auth_code:
+          type: string
+          description: OAuth authorization code from Microsoft callback
+          title: Auth Code
+        state:
+          type: string
+          description: OAuth state parameter for verification
+          title: State
+      required:
+        - auth_code
+        - state
+      title: ServiceAccountAuthCallback
+    ServiceAccountAuthStart:
+      type: object
+      description: Request model to start service account OAuth flow.
+      properties:
+        client_id:
+          type: string
+          description: Microsoft Entra ID Application (Client) ID
+          example: 12345678-1234-1234-1234-123456789012
+          title: Client Id
+        client_secret:
+          type: string
+          description: Microsoft Entra ID Application Client Secret
+          example: abc123~xyz789
+          title: Client Secret
+        tenant_domain:
+          type: string
+          description: 'Microsoft Entra ID Tenant Domain (e.g., contoso.onmicrosoft.com)'
+          example: contoso.onmicrosoft.com
+          title: Tenant Domain
+      required:
+        - client_id
+        - client_secret
+        - tenant_domain
+      title: ServiceAccountAuthStart
+    ServiceAccountAuthStartResponse:
+      type: object
+      description: Response with OAuth URL for service account login.
+      properties:
+        auth_url:
+          type: string
+          description: Microsoft OAuth authorization URL. Redirect the admin to this URL.
+          title: Auth Url
+        state:
+          type: string
+          description: OAuth state parameter for CSRF protection
+          title: State
+      required:
+        - auth_url
+        - state
+      title: ServiceAccountAuthStartResponse
     ServiceCreatePublic:
       type: object
       properties:
@@ -14274,16 +24057,16 @@ components:
           title: Prompt
         completion_model_kwargs:
           anyOf:
-            - "$ref": "#/components/schemas/ModelKwargs"
+            - $ref: '#/components/schemas/ModelKwargs'
             - type: 'null'
         groups:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ModelId"
+            $ref: '#/components/schemas/ModelId'
           title: Groups
         completion_model:
-          "$ref": "#/components/schemas/ModelId"
+          $ref: '#/components/schemas/ModelId'
       required:
         - completion_model
         - name
@@ -14293,13 +24076,12 @@ components:
       type: object
       properties:
         output:
-          type: string
           title: Output
         files:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/FilePublic"
+            $ref: '#/components/schemas/FilePublic'
           title: Files
       required:
         - output
@@ -14311,7 +24093,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         output_format:
           anyOf:
@@ -14352,7 +24134,7 @@ components:
           title: Prompt
         completion_model_kwargs:
           anyOf:
-            - "$ref": "#/components/schemas/ModelKwargs"
+            - $ref: '#/components/schemas/ModelKwargs'
             - type: 'null'
         space_id:
           anyOf:
@@ -14363,12 +24145,12 @@ components:
         groups:
           type: array
           items:
-            "$ref": "#/components/schemas/GroupPublicBase"
+            $ref: '#/components/schemas/GroupPublicBase'
           title: Groups
         completion_model:
-          "$ref": "#/components/schemas/CompletionModelPublic"
+          $ref: '#/components/schemas/CompletionModelPublic'
         user:
-          "$ref": "#/components/schemas/UserPublicBase"
+          $ref: '#/components/schemas/UserPublicBase'
       required:
         - completion_model
         - groups
@@ -14396,11 +24178,11 @@ components:
             - type: string
           title: Output
         completion_model:
-          "$ref": "#/components/schemas/CompletionModelPublic"
+          $ref: '#/components/schemas/CompletionModelPublic'
         references:
           type: array
           items:
-            "$ref": "#/components/schemas/InfoBlobPublic"
+            $ref: '#/components/schemas/InfoBlobPublic'
           title: References
       required:
         - completion_model
@@ -14451,13 +24233,13 @@ components:
           title: Prompt
         completion_model_kwargs:
           anyOf:
-            - "$ref": "#/components/schemas/ModelKwargs"
+            - $ref: '#/components/schemas/ModelKwargs'
             - type: 'null'
         permissions:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         user_id:
           type: string
@@ -14564,25 +24346,254 @@ components:
         messages:
           type: array
           items:
-            "$ref": "#/components/schemas/Message"
+            $ref: '#/components/schemas/Message'
           title: Messages
         feedback:
           anyOf:
-            - "$ref": "#/components/schemas/SessionFeedback"
+            - $ref: '#/components/schemas/SessionFeedback'
             - type: 'null'
       required:
         - id
         - messages
         - name
       title: SessionPublic
+    SetFederationRequest:
+      type: object
+      description: Request model for setting tenant federation config.
+      properties:
+        provider:
+          type: string
+          description: >-
+            Identity provider label (e.g., 'mobilityguard', 'entra_id', 'okta',
+            'auth0')
+          title: Provider
+        discovery_endpoint:
+          type: string
+          description: OIDC discovery endpoint URL
+          examples:
+            - >-
+              https://login.microsoftonline.com/{tenant-id}/v2.0/.well-known/openid-configuration
+          title: Discovery Endpoint
+        client_id:
+          type: string
+          description: OAuth client ID
+          title: Client Id
+        client_secret:
+          type: string
+          description: OAuth client secret
+          minLength: 8
+          title: Client Secret
+        allowed_domains:
+          type: array
+          description: 'Email domains allowed for this tenant (e.g., [''stockholm.se''])'
+          examples:
+            - - stockholm.se
+              - stockholm.gov.se
+          items:
+            type: string
+          title: Allowed Domains
+        canonical_public_origin:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: >-
+            Canonical public origin for this tenant (e.g.,
+            https://tenant.eneo.se). Required for multi-tenant federation to
+            construct redirect_uri
+          examples:
+            - 'https://stockholm.eneo.se'
+          title: Canonical Public Origin
+        redirect_path:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Optional custom redirect path starting with /
+          examples:
+            - /auth/callback
+          title: Redirect Path
+      required:
+        - client_id
+        - client_secret
+        - discovery_endpoint
+        - provider
+      title: SetFederationRequest
+    SetFederationResponse:
+      type: object
+      description: Response model for setting federation config.
+      properties:
+        tenant_id:
+          type: string
+          format: uuid
+          title: Tenant Id
+        provider:
+          type: string
+          title: Provider
+        masked_secret:
+          type: string
+          title: Masked Secret
+        message:
+          type: string
+          title: Message
+      required:
+        - masked_secret
+        - message
+        - provider
+        - tenant_id
+      title: SetFederationResponse
     SettingsPublic:
       type: object
       properties:
         chatbot_widget:
           type: object
           additionalProperties: true
+          default: {}
           title: Chatbot Widget
+        using_templates:
+          type: boolean
+          default: false
+          title: Using Templates
+        tenant_credentials_enabled:
+          type: boolean
+          default: false
+          title: Tenant Credentials Enabled
+        audit_logging_enabled:
+          type: boolean
+          default: true
+          title: Audit Logging Enabled
+        provisioning:
+          type: boolean
+          default: false
+          title: Provisioning
       title: SettingsPublic
+    SharePointSubscriptionPublic:
+      type: object
+      description: Public representation of a SharePoint subscription.
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        user_integration_id:
+          type: string
+          format: uuid
+          title: User Integration Id
+        site_id:
+          type: string
+          title: Site Id
+        subscription_id:
+          type: string
+          title: Subscription Id
+        drive_id:
+          type: string
+          title: Drive Id
+        expires_at:
+          type: string
+          format: date-time
+          title: Expires At
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        is_expired:
+          type: boolean
+          description: True if subscription has already expired
+          title: Is Expired
+        expires_in_hours:
+          type: integer
+          description: Hours until expiration (0 if already expired)
+          title: Expires In Hours
+        owner_email:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Email of subscription owner (None for organization integrations)
+          title: Owner Email
+        owner_type:
+          type: string
+          description: 'Type of owner: ''user'' or ''organization'''
+          title: Owner Type
+      required:
+        - created_at
+        - drive_id
+        - expires_at
+        - expires_in_hours
+        - id
+        - is_expired
+        - owner_type
+        - site_id
+        - subscription_id
+        - user_integration_id
+      title: SharePointSubscriptionPublic
+    SharePointTreeItem:
+      type: object
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          title: Name
+        type:
+          type: string
+          title: Type
+        path:
+          type: string
+          title: Path
+        has_children:
+          type: boolean
+          title: Has Children
+        size:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Size
+        modified:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Modified
+        web_url:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Web Url
+      required:
+        - has_children
+        - id
+        - name
+        - path
+        - type
+      title: SharePointTreeItem
+    SharePointTreeResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SharePointTreeItem'
+          title: Items
+        current_path:
+          type: string
+          title: Current Path
+        parent_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Parent Id
+        drive_id:
+          type: string
+          title: Drive Id
+        site_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Site Id
+      required:
+        - current_path
+        - drive_id
+        - items
+      title: SharePointTreeResponse
     SignedURLRequest:
       type: object
       properties:
@@ -14591,7 +24602,7 @@ components:
           default: 3600
           title: Expires In
         content_disposition:
-          "$ref": "#/components/schemas/ContentDisposition"
+          $ref: '#/components/schemas/ContentDisposition'
           default: attachment
       title: SignedURLRequest
     SignedURLResponse:
@@ -14607,6 +24618,21 @@ components:
         - expires_at
         - url
       title: SignedURLResponse
+    SortField:
+      type: string
+      description: Allowed fields for sorting user lists
+      enum:
+        - email
+        - username
+        - created_at
+      title: SortField
+    SortOrder:
+      type: string
+      description: Sort direction for user lists
+      enum:
+        - asc
+        - desc
+      title: SortOrder
     SpaceDashboard:
       type: object
       properties:
@@ -14614,7 +24640,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         created_at:
           anyOf:
@@ -14643,15 +24669,69 @@ components:
         personal:
           type: boolean
           title: Personal
+        organization:
+          type: boolean
+          title: Organization
+        icon_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Icon ID referencing an uploaded icon
+          title: Icon Id
         applications:
-          "$ref": "#/components/schemas/Applications"
+          $ref: '#/components/schemas/Applications'
+        default_assistant:
+          anyOf:
+            - $ref: '#/components/schemas/DefaultAssistant'
+            - type: 'null'
+        data_retention_days:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Data Retention Days
       required:
         - applications
         - description
         - id
         - name
+        - organization
         - personal
       title: SpaceDashboard
+    SpaceGroupMember:
+      type: object
+      description: A user group that is a member of a space with a specific role.
+      properties:
+        created_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Created At
+        updated_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Updated At
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        role:
+          $ref: '#/components/schemas/SpaceRoleValue'
+        user_count:
+          type: integer
+          default: 0
+          title: User Count
+      required:
+        - id
+        - name
+        - role
+      title: SpaceGroupMember
     SpaceMember:
       type: object
       properties:
@@ -14681,7 +24761,7 @@ components:
             - type: 'null'
           title: Username
         role:
-          "$ref": "#/components/schemas/SpaceRoleValue"
+          $ref: '#/components/schemas/SpaceRoleValue'
       required:
         - email
         - id
@@ -14694,7 +24774,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         created_at:
           anyOf:
@@ -14723,37 +24803,54 @@ components:
         personal:
           type: boolean
           title: Personal
+        organization:
+          type: boolean
+          title: Organization
+        icon_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Icon ID referencing an uploaded icon
+          title: Icon Id
         applications:
-          "$ref": "#/components/schemas/Applications"
+          $ref: '#/components/schemas/Applications'
+        default_assistant:
+          $ref: '#/components/schemas/DefaultAssistant'
+        data_retention_days:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Data Retention Days
         embedding_models:
           type: array
           items:
-            "$ref": "#/components/schemas/EmbeddingModelPublic"
+            $ref: '#/components/schemas/EmbeddingModelPublic'
           title: Embedding Models
         completion_models:
           type: array
           items:
-            "$ref": "#/components/schemas/CompletionModelPublic"
+            $ref: '#/components/schemas/CompletionModelPublic'
           title: Completion Models
         transcription_models:
           type: array
           items:
-            "$ref": "#/components/schemas/TranscriptionModelPublic"
+            $ref: '#/components/schemas/TranscriptionModelPublic'
           title: Transcription Models
         knowledge:
-          "$ref": "#/components/schemas/Knowledge"
+          $ref: '#/components/schemas/Knowledge'
         members:
-          "$ref": "#/components/schemas/PaginatedPermissions_SpaceMember_"
-        default_assistant:
-          "$ref": "#/components/schemas/DefaultAssistant"
+          $ref: '#/components/schemas/PaginatedPermissions_SpaceMember_'
+        group_members:
+          $ref: '#/components/schemas/PaginatedPermissions_SpaceGroupMember_'
         available_roles:
           type: array
           items:
-            "$ref": "#/components/schemas/SpaceRole"
+            $ref: '#/components/schemas/SpaceRole'
           title: Available Roles
         security_classification:
           anyOf:
-            - "$ref": "#/components/schemas/SecurityClassificationPublic"
+            - $ref: '#/components/schemas/SecurityClassificationPublic'
             - type: 'null'
       required:
         - applications
@@ -14762,10 +24859,12 @@ components:
         - default_assistant
         - description
         - embedding_models
+        - group_members
         - id
         - knowledge
         - members
         - name
+        - organization
         - personal
         - security_classification
         - transcription_models
@@ -14774,7 +24873,7 @@ components:
       type: object
       properties:
         value:
-          "$ref": "#/components/schemas/SpaceRoleValue"
+          $ref: '#/components/schemas/SpaceRoleValue'
         label:
           type: string
           readOnly: true
@@ -14797,7 +24896,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         created_at:
           anyOf:
@@ -14826,12 +24925,43 @@ components:
         personal:
           type: boolean
           title: Personal
+        organization:
+          type: boolean
+          title: Organization
+        icon_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          description: Icon ID referencing an uploaded icon
+          title: Icon Id
+        applications:
+          anyOf:
+            - $ref: '#/components/schemas/Applications'
+            - type: 'null'
+        default_assistant:
+          anyOf:
+            - $ref: '#/components/schemas/DefaultAssistant'
+            - type: 'null'
+        data_retention_days:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Data Retention Days
       required:
         - description
         - id
         - name
+        - organization
         - personal
       title: SpaceSparse
+    StateFilter:
+      type: string
+      description: Filter for user state in admin users list
+      enum:
+        - active
+        - inactive
+      title: StateFilter
     Status:
       type: string
       enum:
@@ -14850,7 +24980,7 @@ components:
         items:
           type: array
           items:
-            "$ref": "#/components/schemas/StorageSpaceInfoModel"
+            $ref: '#/components/schemas/StorageSpaceInfoModel'
           title: Items
       required:
         - count
@@ -14901,7 +25031,7 @@ components:
         members:
           type: array
           items:
-            "$ref": "#/components/schemas/StorageSpaceMemberModel"
+            $ref: '#/components/schemas/StorageSpaceMemberModel'
           title: Members
       required:
         - created_at
@@ -14939,6 +25069,142 @@ components:
         - role
         - updated_at
       title: StorageSpaceMemberModel
+    SubscriptionRenewalResult:
+      type: object
+      description: Result of subscription renewal operation.
+      properties:
+        total_subscriptions:
+          type: integer
+          description: Total number of subscriptions found
+          title: Total Subscriptions
+        expired_count:
+          type: integer
+          description: Number of expired subscriptions
+          title: Expired Count
+        recreated:
+          type: integer
+          default: 0
+          description: Number of subscriptions successfully recreated
+          title: Recreated
+        failed:
+          type: integer
+          default: 0
+          description: Number of subscriptions that failed to recreate
+          title: Failed
+        errors:
+          type: array
+          description: Error messages for failed renewals
+          items:
+            type: string
+          title: Errors
+      required:
+        - expired_count
+        - total_subscriptions
+      title: SubscriptionRenewalResult
+    SyncLog:
+      type: object
+      description: Detailed sync operation log.
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        integration_knowledge_id:
+          type: string
+          format: uuid
+          title: Integration Knowledge Id
+        sync_type:
+          type: string
+          title: Sync Type
+        status:
+          type: string
+          title: Status
+        metadata:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          title: Metadata
+        error_message:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Error Message
+        started_at:
+          type: string
+          format: date-time
+          title: Started At
+        completed_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Completed At
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        files_processed:
+          type: integer
+          description: Get files_processed from metadata.
+          readOnly: true
+          title: Files Processed
+        files_deleted:
+          type: integer
+          description: Get files_deleted from metadata.
+          readOnly: true
+          title: Files Deleted
+        pages_processed:
+          type: integer
+          description: Get pages_processed from metadata.
+          readOnly: true
+          title: Pages Processed
+        folders_processed:
+          type: integer
+          description: Get folders_processed from metadata.
+          readOnly: true
+          title: Folders Processed
+        skipped_items:
+          type: integer
+          description: Get skipped_items from metadata.
+          readOnly: true
+          title: Skipped Items
+        skipped_details:
+          type: array
+          description: Get skipped file details from metadata.
+          items:
+            type: object
+            additionalProperties: true
+          readOnly: true
+          title: Skipped Details
+        duration_seconds:
+          anyOf:
+            - type: number
+            - type: 'null'
+          description: Calculate sync duration in seconds.
+          readOnly: true
+          title: Duration Seconds
+        total_items_processed:
+          type: integer
+          description: Total items processed in this sync.
+          readOnly: true
+          title: Total Items Processed
+      required:
+        - created_at
+        - duration_seconds
+        - files_deleted
+        - files_processed
+        - folders_processed
+        - id
+        - integration_knowledge_id
+        - pages_processed
+        - skipped_details
+        - skipped_items
+        - started_at
+        - status
+        - sync_type
+        - total_items_processed
+      title: SyncLog
     Task:
       type: string
       enum:
@@ -14950,6 +25216,8 @@ components:
         - run_app
         - pull_confluence_content
         - pull_sharepoint_content
+        - sync_sharepoint_delta
+        - update_model_usage_stats
       title: Task
     TemplateCreate:
       type: object
@@ -14962,7 +25230,7 @@ components:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/AdditionalField"
+                $ref: '#/components/schemas/AdditionalField'
             - type: 'null'
           title: Additional Fields
       required:
@@ -14976,8 +25244,8 @@ components:
           type: array
           items:
             anyOf:
-              - "$ref": "#/components/schemas/AppTemplatePublic"
-              - "$ref": "#/components/schemas/AssistantTemplatePublic"
+              - $ref: '#/components/schemas/AppTemplatePublic'
+              - $ref: '#/components/schemas/AssistantTemplatePublic'
           title: Items
         count:
           type: integer
@@ -14987,6 +25255,15 @@ components:
         - count
         - items
       title: TemplateListPublic
+    TemplateSettingUpdate:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          title: Enabled
+      required:
+        - enabled
+      title: TemplateSettingUpdate
     TemplateWizard:
       type: object
       properties:
@@ -15005,6 +25282,29 @@ components:
             - type: 'null'
           title: Description
       title: TemplateWizard
+    TenantAppTestResult:
+      type: object
+      description: Result of testing tenant app credentials.
+      properties:
+        success:
+          type: boolean
+          title: Success
+        error_message:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Error Message
+        details:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: >-
+            Additional details about the test (e.g., token acquired
+            successfully)
+          title: Details
+      required:
+        - success
+      title: TenantAppTestResult
     TenantBase:
       type: object
       properties:
@@ -15018,7 +25318,8 @@ components:
           title: Display Name
         quota_limit:
           type: integer
-          default: 2147483647
+          format: int64
+          default: 10737418240
           description: Size in bytes. Default is 10 GB
           title: Quota Limit
         domain:
@@ -15036,7 +25337,7 @@ components:
           default: false
           title: Provisioning
         state:
-          "$ref": "#/components/schemas/TenantState"
+          $ref: '#/components/schemas/TenantState'
           default: active
         security_enabled:
           type: boolean
@@ -15045,6 +25346,224 @@ components:
       required:
         - name
       title: TenantBase
+    TenantCompletionModelCreate:
+      type: object
+      properties:
+        provider_id:
+          type: string
+          format: uuid
+          description: Model provider ID
+          title: Provider Id
+        name:
+          type: string
+          description: >-
+            Model identifier (e.g., 'gpt-4o',
+            'meta-llama/Meta-Llama-3-70B-Instruct')
+          title: Name
+        display_name:
+          type: string
+          description: User-friendly display name
+          title: Display Name
+        token_limit:
+          type: integer
+          default: 128000
+          description: Maximum context tokens
+          title: Token Limit
+        vision:
+          type: boolean
+          default: false
+          description: Supports vision/image inputs
+          title: Vision
+        reasoning:
+          type: boolean
+          default: false
+          description: Supports extended reasoning
+          title: Reasoning
+        hosting:
+          type: string
+          default: swe
+          description: 'Hosting location (swe, eu, usa)'
+          title: Hosting
+        is_active:
+          type: boolean
+          default: true
+          description: Enable in organization
+          title: Is Active
+        is_default:
+          type: boolean
+          default: false
+          description: Set as default model
+          title: Is Default
+      required:
+        - display_name
+        - name
+        - provider_id
+      title: TenantCompletionModelCreate
+    TenantCompletionModelUpdate:
+      type: object
+      properties:
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: 'Model identifier (e.g., ''gpt-4o'', ''claude-3-sonnet'')'
+          title: Name
+        display_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: User-friendly display name
+          title: Display Name
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Model description
+          title: Description
+        token_limit:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          description: Maximum context tokens
+          title: Token Limit
+        vision:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          description: Supports vision/image inputs
+          title: Vision
+        reasoning:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          description: Supports extended reasoning
+          title: Reasoning
+        hosting:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: 'Hosting location (swe, eu, usa)'
+          title: Hosting
+        open_source:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          description: Is the model open source
+          title: Open Source
+        stability:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: 'Model stability (stable, experimental)'
+          title: Stability
+      title: TenantCompletionModelUpdate
+    TenantEmbeddingModelCreate:
+      type: object
+      properties:
+        provider_id:
+          type: string
+          format: uuid
+          description: Model provider ID
+          title: Provider Id
+        name:
+          type: string
+          description: >-
+            Model identifier (e.g., 'text-embedding-3-large',
+            'intfloat/multilingual-e5-large')
+          title: Name
+        display_name:
+          type: string
+          description: User-friendly display name
+          title: Display Name
+        family:
+          type: string
+          default: openai
+          description: 'Model family (e.g., ''openai'', ''huggingface_e5'', ''cohere'', ''voyage'')'
+          title: Family
+        dimensions:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          description: Embedding dimensions
+          title: Dimensions
+        max_input:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          description: Maximum input tokens
+          title: Max Input
+        hosting:
+          type: string
+          default: swe
+          description: 'Hosting location (swe, eu, usa)'
+          title: Hosting
+        is_active:
+          type: boolean
+          default: true
+          description: Enable in organization
+          title: Is Active
+        is_default:
+          type: boolean
+          default: false
+          description: Set as default model
+          title: Is Default
+      required:
+        - display_name
+        - name
+        - provider_id
+      title: TenantEmbeddingModelCreate
+    TenantEmbeddingModelUpdate:
+      type: object
+      properties:
+        display_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: User-friendly display name
+          title: Display Name
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Model description
+          title: Description
+        family:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Model family
+          title: Family
+        dimensions:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          description: Embedding dimensions
+          title: Dimensions
+        max_input:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          description: Maximum input tokens
+          title: Max Input
+        hosting:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: 'Hosting location (swe, eu, usa)'
+          title: Hosting
+        open_source:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          description: Is the model open source
+          title: Open Source
+        stability:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: 'Model stability (stable, experimental)'
+          title: Stability
+      title: TenantEmbeddingModelUpdate
     TenantInDB:
       type: object
       properties:
@@ -15080,6 +25599,11 @@ components:
             - type: string
             - type: 'null'
           title: Display Name
+        slug:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Slug
         quota_limit:
           type: integer
           title: Quota Limit
@@ -15098,7 +25622,7 @@ components:
           default: false
           title: Provisioning
         state:
-          "$ref": "#/components/schemas/TenantState"
+          $ref: '#/components/schemas/TenantState'
           default: active
         security_enabled:
           type: boolean
@@ -15108,13 +25632,47 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ModuleInDB"
+            $ref: '#/components/schemas/ModuleInDB'
           title: Modules
+        api_credentials:
+          type: object
+          additionalProperties: true
+          title: Api Credentials
+        federation_config:
+          type: object
+          additionalProperties: true
+          title: Federation Config
+        crawler_settings:
+          type: object
+          additionalProperties: true
+          title: Crawler Settings
       required:
         - id
         - name
         - quota_limit
       title: TenantInDB
+    TenantInfo:
+      type: object
+      description: Public tenant information for selector grid.
+      example:
+        display_name: Stockholm
+        name: Stockholm Municipality
+        slug: stockholm
+      properties:
+        slug:
+          type: string
+          title: Slug
+        name:
+          type: string
+          title: Name
+        display_name:
+          type: string
+          title: Display Name
+      required:
+        - display_name
+        - name
+        - slug
+      title: TenantInfo
     TenantIntegration:
       type: object
       properties:
@@ -15131,7 +25689,7 @@ components:
           type: string
           title: Description
         integration_type:
-          "$ref": "#/components/schemas/IntegrationType"
+          $ref: '#/components/schemas/IntegrationType'
         integration_id:
           type: string
           format: uuid
@@ -15159,7 +25717,7 @@ components:
         items:
           type: array
           items:
-            "$ref": "#/components/schemas/TenantIntegration"
+            $ref: '#/components/schemas/TenantIntegration'
           title: Items
         count:
           type: integer
@@ -15169,6 +25727,26 @@ components:
         - count
         - items
       title: TenantIntegrationList
+    TenantListResponse:
+      type: object
+      description: List of tenants for selector.
+      example:
+        tenants:
+          - display_name: Stockholm
+            name: Stockholm Municipality
+            slug: stockholm
+          - display_name: Gothenburg
+            name: Gothenburg Municipality
+            slug: goteborg
+      properties:
+        tenants:
+          type: array
+          items:
+            $ref: '#/components/schemas/TenantInfo'
+          title: Tenants
+      required:
+        - tenants
+      title: TenantListResponse
     TenantPublic:
       type: object
       properties:
@@ -15182,7 +25760,8 @@ components:
           title: Display Name
         quota_limit:
           type: integer
-          default: 2147483647
+          format: int64
+          default: 10737418240
           description: Size in bytes. Default is 10 GB
           title: Quota Limit
         domain:
@@ -15200,7 +25779,7 @@ components:
           default: false
           title: Provisioning
         state:
-          "$ref": "#/components/schemas/TenantState"
+          $ref: '#/components/schemas/TenantState'
           default: active
         security_enabled:
           type: boolean
@@ -15217,12 +25796,181 @@ components:
       required:
         - name
       title: TenantPublic
+    TenantSharePointAppCreate:
+      type: object
+      description: Request model for creating/updating tenant SharePoint app credentials.
+      properties:
+        client_id:
+          type: string
+          description: Microsoft Entra ID Application (Client) ID
+          example: 12345678-1234-1234-1234-123456789012
+          title: Client Id
+        client_secret:
+          type: string
+          description: Microsoft Entra ID Application Client Secret
+          example: abc123~xyz789
+          title: Client Secret
+        tenant_domain:
+          type: string
+          description: 'Microsoft Entra ID Tenant Domain (e.g., contoso.onmicrosoft.com)'
+          example: contoso.onmicrosoft.com
+          title: Tenant Domain
+        certificate_path:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Optional path to certificate for certificate-based authentication
+          title: Certificate Path
+      required:
+        - client_id
+        - client_secret
+        - tenant_domain
+      title: TenantSharePointAppCreate
+    TenantSharePointAppPublic:
+      type: object
+      description: Response model for tenant SharePoint app (secret masked).
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        tenant_id:
+          type: string
+          format: uuid
+          title: Tenant Id
+        client_id:
+          type: string
+          title: Client Id
+        client_secret_masked:
+          type: string
+          description: Masked client secret (last 4 chars visible)
+          example: '********xyz789'
+          title: Client Secret Masked
+        tenant_domain:
+          type: string
+          title: Tenant Domain
+        is_active:
+          type: boolean
+          title: Is Active
+        auth_method:
+          type: string
+          description: 'Authentication method: ''tenant_app'' or ''service_account'''
+          example: service_account
+          title: Auth Method
+        service_account_email:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Email of the service account (only for service_account auth method)
+          title: Service Account Email
+        certificate_path:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Certificate Path
+        created_by:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Created By
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      required:
+        - auth_method
+        - certificate_path
+        - client_id
+        - client_secret_masked
+        - created_at
+        - created_by
+        - id
+        - is_active
+        - tenant_domain
+        - tenant_id
+        - updated_at
+      title: TenantSharePointAppPublic
     TenantState:
       type: string
       enum:
         - active
         - suspended
       title: TenantState
+    TenantTranscriptionModelCreate:
+      type: object
+      properties:
+        provider_id:
+          type: string
+          format: uuid
+          description: Model provider ID
+          title: Provider Id
+        name:
+          type: string
+          description: 'Model identifier (e.g., ''whisper-1'', ''distil-whisper-large-v3-en'')'
+          title: Name
+        display_name:
+          type: string
+          description: User-friendly display name
+          title: Display Name
+        hosting:
+          type: string
+          default: swe
+          description: 'Hosting location (swe, eu, usa)'
+          title: Hosting
+        is_active:
+          type: boolean
+          default: true
+          description: Enable in organization
+          title: Is Active
+        is_default:
+          type: boolean
+          default: false
+          description: Set as default model
+          title: Is Default
+      required:
+        - display_name
+        - name
+        - provider_id
+      title: TenantTranscriptionModelCreate
+    TenantTranscriptionModelUpdate:
+      type: object
+      properties:
+        display_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: User-friendly display name
+          title: Display Name
+        description:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Model description
+          title: Description
+        hosting:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: 'Hosting location (swe, eu, usa)'
+          title: Hosting
+        open_source:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          description: Is the model open source
+          title: Open Source
+        stability:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: 'Model stability (stable, experimental)'
+          title: Stability
+      title: TenantTranscriptionModelUpdate
     TenantUpdatePublic:
       type: object
       properties:
@@ -15253,7 +26001,7 @@ components:
           title: Provisioning
         state:
           anyOf:
-            - "$ref": "#/components/schemas/TenantState"
+            - $ref: '#/components/schemas/TenantState'
             - type: 'null'
         security_enabled:
           anyOf:
@@ -15261,6 +26009,172 @@ components:
             - type: 'null'
           title: Security Enabled
       title: TenantUpdatePublic
+    TenantWithMaskedCredentials:
+      type: object
+      description: |-
+        TenantInDB with masked API credentials for safe API responses.
+
+        This model is used when returning tenant data through API endpoints
+        to prevent exposing full API keys. The api_credentials field is
+        automatically masked to show only the last 4 characters of each key.
+
+        Example:
+            Full credential: {"openai": {"api_key": "sk-proj-abc123xyz"}}
+            Masked: {"openai": "...xyz"}
+      properties:
+        created_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Created At
+        updated_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Updated At
+        id:
+          type: string
+          format: uuid
+          title: Id
+        privacy_policy:
+          anyOf:
+            - type: string
+              format: uri
+              maxLength: 2083
+              minLength: 1
+            - type: 'null'
+          title: Privacy Policy
+        name:
+          type: string
+          title: Name
+        display_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Display Name
+        slug:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Slug
+        quota_limit:
+          type: integer
+          title: Quota Limit
+        domain:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Domain
+        zitadel_org_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Zitadel Org Id
+        provisioning:
+          type: boolean
+          default: false
+          title: Provisioning
+        state:
+          $ref: '#/components/schemas/TenantState'
+          default: active
+        security_enabled:
+          type: boolean
+          default: false
+          title: Security Enabled
+        modules:
+          type: array
+          default: []
+          items:
+            $ref: '#/components/schemas/ModuleInDB'
+          title: Modules
+        api_credentials:
+          type: object
+          additionalProperties: true
+          title: Api Credentials
+        federation_config:
+          type: object
+          additionalProperties: true
+          title: Federation Config
+        crawler_settings:
+          type: object
+          additionalProperties: true
+          title: Crawler Settings
+      required:
+        - id
+        - name
+        - quota_limit
+      title: TenantWithMaskedCredentials
+    TokenEstimateBreakdown:
+      type: object
+      description: Breakdown of token usage by source.
+      properties:
+        prompt:
+          type: integer
+          description: Tokens used by assistant prompt
+          title: Prompt
+        text:
+          type: integer
+          description: Tokens used by user input text
+          title: Text
+        files:
+          type: integer
+          description: Total tokens used by all files
+          title: Files
+        file_details:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Per-file token counts
+          title: File Details
+      required:
+        - files
+        - prompt
+        - text
+      title: TokenEstimateBreakdown
+    TokenEstimateRequest:
+      type: object
+      description: Request payload for estimating tokens.
+      properties:
+        text:
+          type: string
+          default: ''
+          description: User input text to evaluate
+          title: Text
+        file_ids:
+          type: array
+          description: List of file IDs to include in the estimate
+          items:
+            type: string
+            format: uuid
+          title: File Ids
+      title: TokenEstimateRequest
+    TokenEstimateResponse:
+      type: object
+      description: Response model for token usage estimation.
+      properties:
+        tokens:
+          type: integer
+          description: Total token count
+          title: Tokens
+        percentage:
+          type: number
+          description: Percentage of context window used
+          title: Percentage
+        limit:
+          type: integer
+          description: Model's context window limit
+          title: Limit
+        breakdown:
+          $ref: '#/components/schemas/TokenEstimateBreakdown'
+          description: Token usage breakdown by source
+      required:
+        - breakdown
+        - limit
+        - percentage
+        - tokens
+      title: TokenEstimateResponse
     TokenUsageSummary:
       type: object
       properties:
@@ -15275,7 +26189,7 @@ components:
         models:
           type: array
           items:
-            "$ref": "#/components/schemas/ModelUsage"
+            $ref: '#/components/schemas/ModelUsage'
           title: Models
         total_input_token_usage:
           type: integer
@@ -15325,14 +26239,14 @@ components:
           type: string
           title: Nickname
         family:
-          "$ref": "#/components/schemas/ModelFamily"
+          $ref: '#/components/schemas/ModelFamily'
         is_deprecated:
           type: boolean
           title: Is Deprecated
         stability:
-          "$ref": "#/components/schemas/ModelStability"
+          $ref: '#/components/schemas/ModelStability'
         hosting:
-          "$ref": "#/components/schemas/ModelHostingLocation"
+          $ref: '#/components/schemas/ModelHostingLocation'
         open_source:
           anyOf:
             - type: boolean
@@ -15350,7 +26264,7 @@ components:
           title: Hf Link
         org:
           anyOf:
-            - "$ref": "#/components/schemas/ModelOrg"
+            - $ref: '#/components/schemas/ModelOrg'
             - type: 'null'
         can_access:
           type: boolean
@@ -15360,6 +26274,11 @@ components:
           type: boolean
           default: true
           title: Is Locked
+        lock_reason:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Lock Reason
         is_org_enabled:
           type: boolean
           default: false
@@ -15368,10 +26287,37 @@ components:
           type: boolean
           default: false
           title: Is Org Default
+        credential_provider:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Credential Provider
         security_classification:
           anyOf:
-            - "$ref": "#/components/schemas/SecurityClassificationPublic"
+            - $ref: '#/components/schemas/SecurityClassificationPublic'
             - type: 'null'
+        tenant_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Tenant Id
+        provider_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Provider Id
+        provider_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Name
+        provider_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Type
       required:
         - family
         - hosting
@@ -15395,14 +26341,14 @@ components:
           type: string
           title: Nickname
         family:
-          "$ref": "#/components/schemas/ModelFamily"
+          $ref: '#/components/schemas/ModelFamily'
         is_deprecated:
           type: boolean
           title: Is Deprecated
         stability:
-          "$ref": "#/components/schemas/ModelStability"
+          $ref: '#/components/schemas/ModelStability'
         hosting:
-          "$ref": "#/components/schemas/ModelHostingLocation"
+          $ref: '#/components/schemas/ModelHostingLocation'
         open_source:
           anyOf:
             - type: boolean
@@ -15420,7 +26366,7 @@ components:
           title: Hf Link
         org:
           anyOf:
-            - "$ref": "#/components/schemas/ModelOrg"
+            - $ref: '#/components/schemas/ModelOrg'
             - type: 'null'
         can_access:
           type: boolean
@@ -15430,6 +26376,11 @@ components:
           type: boolean
           default: true
           title: Is Locked
+        lock_reason:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Lock Reason
         is_org_enabled:
           type: boolean
           default: false
@@ -15438,10 +26389,37 @@ components:
           type: boolean
           default: false
           title: Is Org Default
+        credential_provider:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Credential Provider
         security_classification:
           anyOf:
-            - "$ref": "#/components/schemas/SecurityClassificationPublic"
+            - $ref: '#/components/schemas/SecurityClassificationPublic'
             - type: 'null'
+        tenant_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Tenant Id
+        provider_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Provider Id
+        provider_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Name
+        provider_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Provider Type
         meets_security_classification:
           anyOf:
             - type: boolean
@@ -15471,7 +26449,7 @@ components:
           title: Is Org Default
         security_classification:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
           title: Security Classification
       title: TranscriptionModelUpdate
@@ -15499,10 +26477,34 @@ components:
       required:
         - target_space_id
       title: TransferRequest
+    UpdateIntegrationKnowledgeRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          title: Name
+      required:
+        - name
+      title: UpdateIntegrationKnowledgeRequest
+    UpdateIntegrationKnowledgeWrapperRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          title: Name
+      required:
+        - name
+      title: UpdateIntegrationKnowledgeWrapperRequest
     UpdateInterval:
       type: string
+      description: |-
+        Defines how frequently a website should be crawled.
+
+        Why: Provides flexible scheduling options for automated crawling.
       enum:
         - never
+        - daily
+        - every_other_day
         - weekly
       title: UpdateInterval
     UpdateSpaceDryRunResponse:
@@ -15511,37 +26513,37 @@ components:
         assistants:
           type: array
           items:
-            "$ref": "#/components/schemas/AssistantSparse"
+            $ref: '#/components/schemas/AssistantSparse'
           title: Assistants
         group_chats:
           type: array
           items:
-            "$ref": "#/components/schemas/GroupChatSparse"
+            $ref: '#/components/schemas/GroupChatSparse'
           title: Group Chats
         services:
           type: array
           items:
-            "$ref": "#/components/schemas/ServiceSparse"
+            $ref: '#/components/schemas/ServiceSparse'
           title: Services
         apps:
           type: array
           items:
-            "$ref": "#/components/schemas/AppSparse"
+            $ref: '#/components/schemas/AppSparse'
           title: Apps
         completion_models:
           type: array
           items:
-            "$ref": "#/components/schemas/CompletionModelPublic"
+            $ref: '#/components/schemas/CompletionModelPublic'
           title: Completion Models
         embedding_models:
           type: array
           items:
-            "$ref": "#/components/schemas/EmbeddingModelPublic"
+            $ref: '#/components/schemas/EmbeddingModelPublic'
           title: Embedding Models
         transcription_models:
           type: array
           items:
-            "$ref": "#/components/schemas/TranscriptionModelPublic"
+            $ref: '#/components/schemas/TranscriptionModelPublic'
           title: Transcription Models
       required:
         - apps
@@ -15552,11 +26554,19 @@ components:
         - services
         - transcription_models
       title: UpdateSpaceDryRunResponse
+    UpdateSpaceGroupMemberRequest:
+      type: object
+      properties:
+        role:
+          $ref: '#/components/schemas/SpaceRoleValue'
+      required:
+        - role
+      title: UpdateSpaceGroupMemberRequest
     UpdateSpaceMemberRequest:
       type: object
       properties:
         role:
-          "$ref": "#/components/schemas/SpaceRoleValue"
+          $ref: '#/components/schemas/SpaceRoleValue'
       required:
         - role
       title: UpdateSpaceMemberRequest
@@ -15566,7 +26576,7 @@ components:
         assistants:
           type: array
           items:
-            "$ref": "#/components/schemas/ToolAssistant"
+            $ref: '#/components/schemas/ToolAssistant'
           title: Assistants
       required:
         - assistants
@@ -15585,7 +26595,7 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-          description: Unique username (optional, will use email prefix if not provided)
+          description: 'Unique username (optional, will use email prefix if not provided)'
           examples:
             - john.doe
           title: Username
@@ -15615,7 +26625,7 @@ components:
           examples:
             - []
           items:
-            "$ref": "#/components/schemas/ModelId"
+            $ref: '#/components/schemas/ModelId'
           title: Roles
         predefined_roles:
           type: array
@@ -15624,7 +26634,7 @@ components:
           examples:
             - []
           items:
-            "$ref": "#/components/schemas/ModelId"
+            $ref: '#/components/schemas/ModelId'
           title: Predefined Roles
       required:
         - email
@@ -15643,7 +26653,7 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-          description: Unique username (optional, will use email prefix if not provided)
+          description: 'Unique username (optional, will use email prefix if not provided)'
           examples:
             - john.doe
           title: Username
@@ -15673,7 +26683,7 @@ components:
           examples:
             - []
           items:
-            "$ref": "#/components/schemas/ModelId"
+            $ref: '#/components/schemas/ModelId'
           title: Roles
         predefined_roles:
           type: array
@@ -15682,7 +26692,7 @@ components:
           examples:
             - []
           items:
-            "$ref": "#/components/schemas/ModelId"
+            $ref: '#/components/schemas/ModelId'
           title: Predefined Roles
         tenant_id:
           type: string
@@ -15706,7 +26716,7 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-          description: Unique username (optional, will use email prefix if not provided)
+          description: 'Unique username (optional, will use email prefix if not provided)'
           examples:
             - john.doe
           title: Username
@@ -15745,21 +26755,21 @@ components:
           type: boolean
           title: Is Active
         state:
-          "$ref": "#/components/schemas/UserState"
+          $ref: '#/components/schemas/UserState'
         roles:
           type: array
           items:
-            "$ref": "#/components/schemas/RolePublic"
+            $ref: '#/components/schemas/RolePublic'
           title: Roles
         predefined_roles:
           type: array
           items:
-            "$ref": "#/components/schemas/PredefinedRolePublic"
+            $ref: '#/components/schemas/PredefinedRolePublic'
           title: Predefined Roles
         user_groups:
           type: array
           items:
-            "$ref": "#/components/schemas/UserGroupRead"
+            $ref: '#/components/schemas/UserGroupRead'
           title: User Groups
       required:
         - email
@@ -15787,7 +26797,7 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-          description: Unique username (optional, will use email prefix if not provided)
+          description: 'Unique username (optional, will use email prefix if not provided)'
           examples:
             - john.doe
           title: Username
@@ -15820,7 +26830,7 @@ components:
           default: true
           title: Is Active
         state:
-          "$ref": "#/components/schemas/UserState"
+          $ref: '#/components/schemas/UserState'
         tenant_id:
           type: string
           format: uuid
@@ -15834,13 +26844,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/RoleInDB"
+            $ref: '#/components/schemas/RoleInDB'
           title: Roles
         predefined_roles:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/PredefinedRoleInDB"
+            $ref: '#/components/schemas/PredefinedRoleInDB'
           title: Predefined Roles
         created_at:
           anyOf:
@@ -15858,13 +26868,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/UserGroupInDBRead"
+            $ref: '#/components/schemas/UserGroupInDBRead'
           title: User Groups
         tenant:
-          "$ref": "#/components/schemas/TenantInDB"
+          $ref: '#/components/schemas/TenantInDB'
         api_key:
           anyOf:
-            - "$ref": "#/components/schemas/ApiKey"
+            - $ref: '#/components/schemas/ApiKey'
             - type: 'null'
         quota_used:
           type: integer
@@ -15879,7 +26889,7 @@ components:
           title: Deleted At
         access_token:
           anyOf:
-            - "$ref": "#/components/schemas/AccessToken"
+            - $ref: '#/components/schemas/AccessToken'
             - type: 'null'
         modules:
           type: array
@@ -15890,14 +26900,15 @@ components:
         user_groups_ids:
           type: array
           items:
-            type: integer
+            type: string
+            format: uuid
           readOnly: true
           title: User Groups Ids
           uniqueItems: true
         permissions:
           type: array
           items:
-            "$ref": "#/components/schemas/Permission"
+            $ref: '#/components/schemas/Permission'
           readOnly: true
           title: Permissions
           uniqueItems: true
@@ -15927,7 +26938,7 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-          description: Unique username (optional, will use email prefix if not provided)
+          description: 'Unique username (optional, will use email prefix if not provided)'
           examples:
             - john.doe
           title: Username
@@ -15966,24 +26977,24 @@ components:
           type: boolean
           title: Is Active
         state:
-          "$ref": "#/components/schemas/UserState"
+          $ref: '#/components/schemas/UserState'
         roles:
           type: array
           items:
-            "$ref": "#/components/schemas/RolePublic"
+            $ref: '#/components/schemas/RolePublic'
           title: Roles
         predefined_roles:
           type: array
           items:
-            "$ref": "#/components/schemas/PredefinedRolePublic"
+            $ref: '#/components/schemas/PredefinedRolePublic'
           title: Predefined Roles
         user_groups:
           type: array
           items:
-            "$ref": "#/components/schemas/UserGroupRead"
+            $ref: '#/components/schemas/UserGroupRead'
           title: User Groups
         api_key:
-          "$ref": "#/components/schemas/ApiKey"
+          $ref: '#/components/schemas/ApiKey'
       required:
         - api_key
         - email
@@ -16093,7 +27104,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/UserPublicBase"
+            $ref: '#/components/schemas/UserPublicBase'
           title: Users
       required:
         - id
@@ -16137,7 +27148,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ModelId"
+            $ref: '#/components/schemas/ModelId'
           title: Users
       title: UserGroupUpdateRequest
     UserInDB:
@@ -16154,7 +27165,7 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-          description: Unique username (optional, will use email prefix if not provided)
+          description: 'Unique username (optional, will use email prefix if not provided)'
           examples:
             - john.doe
           title: Username
@@ -16187,7 +27198,7 @@ components:
           default: true
           title: Is Active
         state:
-          "$ref": "#/components/schemas/UserState"
+          $ref: '#/components/schemas/UserState'
         tenant_id:
           type: string
           format: uuid
@@ -16201,13 +27212,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/RoleInDB"
+            $ref: '#/components/schemas/RoleInDB'
           title: Roles
         predefined_roles:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/PredefinedRoleInDB"
+            $ref: '#/components/schemas/PredefinedRoleInDB'
           title: Predefined Roles
         created_at:
           anyOf:
@@ -16225,13 +27236,13 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/UserGroupInDBRead"
+            $ref: '#/components/schemas/UserGroupInDBRead'
           title: User Groups
         tenant:
-          "$ref": "#/components/schemas/TenantInDB"
+          $ref: '#/components/schemas/TenantInDB'
         api_key:
           anyOf:
-            - "$ref": "#/components/schemas/ApiKeyInDB"
+            - $ref: '#/components/schemas/ApiKeyInDB'
             - type: 'null'
         quota_used:
           type: integer
@@ -16253,14 +27264,15 @@ components:
         user_groups_ids:
           type: array
           items:
-            type: integer
+            type: string
+            format: uuid
           readOnly: true
           title: User Groups Ids
           uniqueItems: true
         permissions:
           type: array
           items:
-            "$ref": "#/components/schemas/Permission"
+            $ref: '#/components/schemas/Permission'
           readOnly: true
           title: Permissions
           uniqueItems: true
@@ -16290,7 +27302,7 @@ components:
           type: string
           title: Description
         integration_type:
-          "$ref": "#/components/schemas/IntegrationType"
+          $ref: '#/components/schemas/IntegrationType'
         tenant_integration_id:
           type: string
           format: uuid
@@ -16298,6 +27310,20 @@ components:
         connected:
           type: boolean
           title: Connected
+        auth_type:
+          type: string
+          default: user_oauth
+          title: Auth Type
+        tenant_app_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: 'null'
+          title: Tenant App Id
+        tenant_app_configured:
+          type: boolean
+          default: true
+          title: Tenant App Configured
       required:
         - connected
         - description
@@ -16311,7 +27337,7 @@ components:
         items:
           type: array
           items:
-            "$ref": "#/components/schemas/UserIntegration"
+            $ref: '#/components/schemas/UserIntegration'
           title: Items
         count:
           type: integer
@@ -16344,7 +27370,7 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-          description: Unique username (optional, will use email prefix if not provided)
+          description: 'Unique username (optional, will use email prefix if not provided)'
           examples:
             - john.doe
           title: Username
@@ -16381,17 +27407,17 @@ components:
         roles:
           type: array
           items:
-            "$ref": "#/components/schemas/RolePublic"
+            $ref: '#/components/schemas/RolePublic'
           title: Roles
         predefined_roles:
           type: array
           items:
-            "$ref": "#/components/schemas/PredefinedRolePublic"
+            $ref: '#/components/schemas/PredefinedRolePublic'
           title: Predefined Roles
         user_groups:
           type: array
           items:
-            "$ref": "#/components/schemas/UserGroupRead"
+            $ref: '#/components/schemas/UserGroupRead'
           title: User Groups
       required:
         - email
@@ -16414,7 +27440,7 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-          description: Unique username (optional, will use email prefix if not provided)
+          description: 'Unique username (optional, will use email prefix if not provided)'
           examples:
             - john.doe
           title: Username
@@ -16560,7 +27586,7 @@ components:
           type: array
           description: Models used by this user with their usage
           items:
-            "$ref": "#/components/schemas/ModelUsage"
+            $ref: '#/components/schemas/ModelUsage'
           title: Models Used
       required:
         - email
@@ -16579,7 +27605,7 @@ components:
           type: array
           description: List of users with their token usage
           items:
-            "$ref": "#/components/schemas/UserTokenUsage"
+            $ref: '#/components/schemas/UserTokenUsage'
           title: Users
         start_date:
           type: string
@@ -16624,7 +27650,7 @@ components:
       description: Response model for single user detail endpoint
       properties:
         user:
-          "$ref": "#/components/schemas/UserTokenUsage"
+          $ref: '#/components/schemas/UserTokenUsage'
       required:
         - user
       title: UserTokenUsageSummaryDetail
@@ -16669,24 +27695,27 @@ components:
           anyOf:
             - type: array
               items:
-                "$ref": "#/components/schemas/ModelId"
+                $ref: '#/components/schemas/ModelId'
             - type: 'null'
           description: List of custom role IDs to assign (replaces existing roles)
           examples:
             - []
           title: Roles
         predefined_roles:
-          type: array
-          description: List of predefined role IDs to assign (replaces existing predefined
+          anyOf:
+            - type: array
+              items:
+                $ref: '#/components/schemas/ModelId'
+            - type: 'null'
+          description: >-
+            List of predefined role IDs to assign (replaces existing predefined
             roles)
           examples:
             - []
-          items:
-            "$ref": "#/components/schemas/ModelId"
           title: Predefined Roles
         state:
           anyOf:
-            - "$ref": "#/components/schemas/UserState"
+            - $ref: '#/components/schemas/UserState'
             - type: 'null'
           description: User state (invited/active/inactive)
           examples:
@@ -16713,6 +27742,40 @@ components:
         - msg
         - type
       title: ValidationError
+    WatchdogMetrics:
+      type: object
+      description: Watchdog activity metrics.
+      properties:
+        age_seconds:
+          anyOf:
+            - type: number
+            - type: 'null'
+          title: Age Seconds
+        zombies_reconciled:
+          type: integer
+          default: 0
+          title: Zombies Reconciled
+        expired_killed:
+          type: integer
+          default: 0
+          title: Expired Killed
+        rescued:
+          type: integer
+          default: 0
+          title: Rescued
+        early_zombies_failed:
+          type: integer
+          default: 0
+          title: Early Zombies Failed
+        long_running_failed:
+          type: integer
+          default: 0
+          title: Long Running Failed
+        slots_released:
+          type: integer
+          default: 0
+          title: Slots Released
+      title: WatchdogMetrics
     WebSearchResultPublic:
       type: object
       properties:
@@ -16747,15 +27810,29 @@ components:
           default: false
           title: Download Files
         crawl_type:
-          "$ref": "#/components/schemas/CrawlType"
+          $ref: '#/components/schemas/CrawlType'
           default: crawl
         update_interval:
-          "$ref": "#/components/schemas/UpdateInterval"
+          $ref: '#/components/schemas/UpdateInterval'
           default: never
         embedding_model:
           anyOf:
-            - "$ref": "#/components/schemas/ModelId"
+            - $ref: '#/components/schemas/ModelId'
             - type: 'null'
+        http_auth_username:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Username for HTTP Basic Authentication (optional)
+          title: Http Auth Username
+        http_auth_password:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: >-
+            Password for HTTP Basic Authentication (optional). Must be provided
+            together with username.
+          title: Http Auth Password
       required:
         - url
       title: WebsiteCreate
@@ -16784,17 +27861,84 @@ components:
           default: false
           title: Download Files
         crawl_type:
-          "$ref": "#/components/schemas/CrawlType"
+          $ref: '#/components/schemas/CrawlType'
           default: crawl
         update_interval:
-          "$ref": "#/components/schemas/UpdateInterval"
+          $ref: '#/components/schemas/UpdateInterval'
           default: never
         embedding_model:
-          "$ref": "#/components/schemas/ModelId"
+          $ref: '#/components/schemas/ModelId'
       required:
         - embedding_model
         - url
       title: WebsiteCreateRequestDeprecated
+    WebsiteExistsResponse:
+      type: object
+      description: >-
+        Response model for checking if a website URL exists on the Organization
+        space.
+      properties:
+        website_id:
+          type: string
+          format: uuid
+          title: Website Id
+        space_id:
+          type: string
+          format: uuid
+          title: Space Id
+        space_name:
+          type: string
+          title: Space Name
+        url:
+          type: string
+          title: Url
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Name
+        update_interval:
+          $ref: '#/components/schemas/UpdateInterval'
+        last_crawled_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          title: Last Crawled At
+        pages_crawled:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Pages Crawled
+        pages_failed:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Pages Failed
+        files_downloaded:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Files Downloaded
+        files_failed:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Files Failed
+        crawl_status:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Crawl Status
+      required:
+        - last_crawled_at
+        - name
+        - space_id
+        - space_name
+        - update_interval
+        - url
+        - website_id
+      title: WebsiteExistsResponse
     WebsiteMetadata:
       type: object
       properties:
@@ -16827,7 +27971,7 @@ components:
           type: array
           default: []
           items:
-            "$ref": "#/components/schemas/ResourcePermission"
+            $ref: '#/components/schemas/ResourcePermission'
           title: Permissions
         name:
           anyOf:
@@ -16845,25 +27989,56 @@ components:
           type: boolean
           title: Download Files
         crawl_type:
-          "$ref": "#/components/schemas/CrawlType"
+          $ref: '#/components/schemas/CrawlType'
         update_interval:
-          "$ref": "#/components/schemas/UpdateInterval"
+          $ref: '#/components/schemas/UpdateInterval'
         latest_crawl:
           anyOf:
-            - "$ref": "#/components/schemas/intric__websites__presentation__website_models__CrawlRunPublic"
+            - $ref: >-
+                #/components/schemas/intric__websites__presentation__website_models__CrawlRunPublic
             - type: 'null'
         embedding_model:
-          "$ref": "#/components/schemas/EmbeddingModelPublic"
+          $ref: '#/components/schemas/EmbeddingModelPublic'
         metadata:
-          "$ref": "#/components/schemas/WebsiteMetadata"
+          $ref: '#/components/schemas/WebsiteMetadata'
+        requires_http_auth:
+          type: boolean
+          description: >-
+            Whether this website requires HTTP Basic Authentication. Credentials
+            are never exposed via API.
+          title: Requires Http Auth
+        consecutive_failures:
+          type: integer
+          default: 0
+          description: >-
+            Number of consecutive crawl failures. Resets to 0 on successful
+            crawl.
+          title: Consecutive Failures
+        next_retry_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          description: >-
+            When to retry after failures (null = no backoff). Uses exponential
+            backoff: 1h → 2h → 4h → 8h → 16h → 24h max.
+          title: Next Retry At
+        is_auto_disabled:
+          type: boolean
+          description: >-
+            True if website was auto-disabled after 10 consecutive failures.
+            User must manually change update_interval to re-enable.
+          title: Is Auto Disabled
       required:
         - crawl_type
         - download_files
         - embedding_model
         - id
+        - is_auto_disabled
         - latest_crawl
         - metadata
         - name
+        - requires_http_auth
         - space_id
         - update_interval
         - url
@@ -16883,11 +28058,27 @@ components:
           type: boolean
           title: Download Files
         crawl_type:
-          "$ref": "#/components/schemas/CrawlType"
+          $ref: '#/components/schemas/CrawlType'
           title: Crawl Type
         update_interval:
-          "$ref": "#/components/schemas/UpdateInterval"
+          $ref: '#/components/schemas/UpdateInterval'
           title: Update Interval
+        http_auth_username:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: >-
+            Username for HTTP Basic Authentication. Set to null to remove auth.
+            Must be provided with password.
+          title: Http Auth Username
+        http_auth_password:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: >-
+            Password for HTTP Basic Authentication. Set to null to remove auth.
+            Must be provided with username.
+          title: Http Auth Password
       title: WebsiteUpdate
     WizardType:
       type: string
@@ -16895,6 +28086,323 @@ components:
         - attachments
         - groups
       title: WizardType
+    intric__tenants__presentation__tenant_credentials_router__CredentialInfo:
+      type: object
+      description: |-
+        Information about a configured credential.
+
+        Example:
+            {
+                "provider": "openai",
+                "masked_key": "...xyz9",
+                "configured_at": "2025-10-07T12:34:56.789Z",
+                "encryption_status": "encrypted",
+                "config": {
+                    "endpoint": "https://my-resource.openai.azure.com",
+                    "api_version": "2024-02-15-preview"
+                }
+            }
+      properties:
+        provider:
+          type: string
+          description: LLM provider name
+          examples:
+            - openai
+            - azure
+          title: Provider
+        masked_key:
+          type: string
+          description: Last 4 characters of API key for identification
+          examples:
+            - ...xyz9
+            - ...abc1
+          title: Masked Key
+        configured_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          description: Timestamp when credential was last updated
+          title: Configured At
+        encryption_status:
+          type: string
+          description: >-
+            Encryption status of stored credential. 'encrypted' = secure at rest
+            (Fernet encryption), 'plaintext' = needs migration for security
+            compliance
+          enum:
+            - encrypted
+            - plaintext
+          examples:
+            - encrypted
+          title: Encryption Status
+        config:
+          type: object
+          additionalProperties: true
+          description: 'Provider-specific configuration (e.g., Azure endpoint, api_version)'
+          examples:
+            - api_version: 2024-02-15-preview
+              deployment_name: gpt-4-sweden
+              endpoint: 'https://sweden.openai.azure.com/'
+          title: Config
+      required:
+        - encryption_status
+        - masked_key
+        - provider
+      title: CredentialInfo
+    intric__tenants__presentation__tenant_credentials_router__ListCredentialsResponse:
+      type: object
+      description: |-
+        Response model for listing tenant credentials.
+
+        Example:
+            {
+                "credentials": [
+                    {
+                        "provider": "openai",
+                        "masked_key": "...xyz9",
+                        "configured_at": "2025-10-07T12:34:56.789Z",
+                        "encryption_status": "encrypted",
+                        "config": {}
+                    },
+                    {
+                        "provider": "azure",
+                        "masked_key": "...abc3",
+                        "configured_at": "2025-10-07T12:45:00.123Z",
+                        "encryption_status": "plaintext",
+                        "config": {
+                            "endpoint": "https://my-resource.openai.azure.com",
+                            "api_version": "2024-02-15-preview",
+                            "deployment_name": "gpt-4"
+                        }
+                    }
+                ]
+            }
+      properties:
+        credentials:
+          type: array
+          items:
+            $ref: >-
+              #/components/schemas/intric__tenants__presentation__tenant_credentials_router__CredentialInfo
+          title: Credentials
+      required:
+        - credentials
+      title: ListCredentialsResponse
+    intric__tenants__presentation__tenant_credentials_router__SetCredentialRequest:
+      type: object
+      description: |-
+        Request model for setting tenant API credentials.
+
+        Provider-specific field requirements:
+        - OpenAI, Anthropic, Mistral, Berget, GDM, OVHCloud: api_key only
+        - vLLM: api_key + endpoint (required)
+        - Azure: api_key + endpoint + api_version (required)
+
+        Example for OpenAI:
+            {
+                "api_key": "sk-proj-abc123..."
+            }
+
+        Example for Azure:
+            {
+                "api_key": "abc123...",
+                "endpoint": "https://my-resource.openai.azure.com",
+                "api_version": "2024-02-15-preview"
+            }
+
+        Example for vLLM:
+            {
+                "api_key": "vllm-secret-key",
+                "endpoint": "http://tenant-vllm:8000"
+            }
+      properties:
+        api_key:
+          type: string
+          description: API key for the provider
+          minLength: 8
+          title: Api Key
+        endpoint:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Azure OpenAI endpoint (required for Azure provider)
+          title: Endpoint
+        api_version:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Azure OpenAI API version (required for Azure provider)
+          title: Api Version
+        deployment_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Azure OpenAI deployment name (required for Azure provider)
+          title: Deployment Name
+      required:
+        - api_key
+      title: SetCredentialRequest
+    intric__tenants__presentation__tenant_credentials_router__SetCredentialResponse:
+      type: object
+      description: >-
+        Response model for setting tenant API credentials.
+
+
+        Returns the tenant ID, provider, masked API key (last 4 chars for
+        verification),
+
+        and confirmation message. Sensitive data (api_key, endpoint,
+        api_version) are
+
+        not returned for security.
+
+
+        Example:
+            {
+                "tenant_id": "123e4567-e89b-12d3-a456-426614174000",
+                "provider": "openai",
+                "masked_key": "...xyz9",
+                "message": "API credential for openai set successfully",
+                "set_at": "2025-10-22T10:00:00+00:00"
+            }
+      properties:
+        tenant_id:
+          type: string
+          format: uuid
+          title: Tenant Id
+        provider:
+          type: string
+          title: Provider
+        masked_key:
+          type: string
+          title: Masked Key
+        message:
+          type: string
+          title: Message
+        set_at:
+          type: string
+          format: date-time
+          title: Set At
+      required:
+        - masked_key
+        - message
+        - provider
+        - set_at
+        - tenant_id
+      title: SetCredentialResponse
+    intric__tenants__presentation__tenant_self_credentials_router__CredentialInfo:
+      type: object
+      properties:
+        provider:
+          type: string
+          description: LLM provider name
+          examples:
+            - openai
+            - azure
+          title: Provider
+        masked_key:
+          type: string
+          description: Last 4 characters of API key for identification
+          examples:
+            - ...xyz9
+            - ...abc1
+          title: Masked Key
+        configured_at:
+          anyOf:
+            - type: string
+              format: date-time
+            - type: 'null'
+          description: Timestamp when credential was last updated
+          title: Configured At
+        encryption_status:
+          type: string
+          description: >-
+            Encryption status of stored credential. 'encrypted' = secure at rest
+            (Fernet encryption), 'plaintext' = needs migration for security
+            compliance
+          enum:
+            - encrypted
+            - plaintext
+          examples:
+            - encrypted
+          title: Encryption Status
+        config:
+          type: object
+          additionalProperties: true
+          description: 'Provider-specific configuration (e.g., Azure endpoint, api_version)'
+          examples:
+            - api_version: 2024-02-15-preview
+              deployment_name: gpt-4-sweden
+              endpoint: 'https://sweden.openai.azure.com/'
+          title: Config
+      required:
+        - encryption_status
+        - masked_key
+        - provider
+      title: CredentialInfo
+    intric__tenants__presentation__tenant_self_credentials_router__ListCredentialsResponse:
+      type: object
+      properties:
+        credentials:
+          type: array
+          items:
+            $ref: >-
+              #/components/schemas/intric__tenants__presentation__tenant_self_credentials_router__CredentialInfo
+          title: Credentials
+      required:
+        - credentials
+      title: ListCredentialsResponse
+    intric__tenants__presentation__tenant_self_credentials_router__SetCredentialRequest:
+      type: object
+      properties:
+        api_key:
+          type: string
+          description: API key for the provider
+          minLength: 8
+          title: Api Key
+        endpoint:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Azure OpenAI endpoint (required for Azure provider)
+          title: Endpoint
+        api_version:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Azure OpenAI API version (required for Azure provider)
+          title: Api Version
+        deployment_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: Azure OpenAI deployment name (required for Azure provider)
+          title: Deployment Name
+      required:
+        - api_key
+      title: SetCredentialRequest
+    intric__tenants__presentation__tenant_self_credentials_router__SetCredentialResponse:
+      type: object
+      properties:
+        provider:
+          type: string
+          title: Provider
+        masked_key:
+          type: string
+          title: Masked Key
+        message:
+          type: string
+          title: Message
+        set_at:
+          type: string
+          format: date-time
+          title: Set At
+      required:
+        - masked_key
+        - message
+        - provider
+        - set_at
+      title: SetCredentialResponse
     intric__websites__crawl_dependencies__crawl_models__CrawlRunPublic:
       type: object
       properties:
@@ -16934,9 +28442,16 @@ components:
             - type: integer
             - type: 'null'
           title: Files Failed
+        failure_summary:
+          anyOf:
+            - type: object
+              additionalProperties:
+                type: integer
+            - type: 'null'
+          title: Failure Summary
         status:
           anyOf:
-            - "$ref": "#/components/schemas/Status"
+            - $ref: '#/components/schemas/Status'
             - type: 'null'
           default: queued
         result_location:
@@ -16992,8 +28507,15 @@ components:
             - type: integer
             - type: 'null'
           title: Files Failed
+        failure_summary:
+          anyOf:
+            - type: object
+              additionalProperties:
+                type: integer
+            - type: 'null'
+          title: Failure Summary
         status:
-          "$ref": "#/components/schemas/Status"
+          $ref: '#/components/schemas/Status'
         result_location:
           anyOf:
             - type: string
@@ -17024,7 +28546,7 @@ components:
       type: oauth2
       flows:
         password:
-          tokenUrl: "/api/v1/users/login/token/"
+          tokenUrl: /api/v1/users/login/token/
           scopes: {}
     APIKeyHeader:
       type: apiKey
@@ -17034,6 +28556,49 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: https://api-i-test.sundsvall.se/authorize
+          authorizationUrl: 'https://test.com'
           scopes: {}
 x-wso2-api-key-header: ApiKey
+x-wso2-auth-header: Authorization
+x-wso2-cors:
+  corsConfigurationEnabled: true
+  accessControlAllowOrigins:
+    - '*'
+  accessControlAllowCredentials: false
+  accessControlAllowHeaders:
+    - authorization
+    - Access-Control-Allow-Origin
+    - Content-Type
+    - SOAPAction
+    - apikey
+    - Internal-Key
+    - testKey
+    - api-key
+    - X-Authorization
+    - Authorization
+  accessControlAllowMethods:
+    - GET
+    - PUT
+    - POST
+    - DELETE
+    - PATCH
+    - OPTIONS
+  empty: false
+x-wso2-production-endpoints:
+  urls:
+    - 'https://eneo-test.sundsvall.se/api/v1/'
+  type: http
+x-wso2-sandbox-endpoints:
+  urls:
+    - 'https://eneo-test.sundsvall.se/api/v1/'
+  type: http
+x-wso2-basePath: /eneo-sundsvall/1.2
+x-wso2-transports:
+  - https
+x-wso2-application-security:
+  security-types:
+    - oauth2
+  optional: false
+x-wso2-response-cache:
+  enabled: false
+  cacheTimeoutInSeconds: 300

--- a/src/test/java/se/sundsvall/ai/flow/integration/eneo/EneoMapperTest.java
+++ b/src/test/java/se/sundsvall/ai/flow/integration/eneo/EneoMapperTest.java
@@ -3,11 +3,14 @@ package se.sundsvall.ai.flow.integration.eneo;
 import generated.eneo.ai.AppRunPublic;
 import generated.eneo.ai.ServiceOutput;
 import generated.eneo.ai.Status;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class EneoMapperTest {
 
@@ -21,22 +24,8 @@ class EneoMapperTest {
 
 		assertThat(runService).isNotNull().satisfies(service -> {
 			assertThat(service.getInput()).isEqualTo(input);
-			assertThat(service.getFiles()).hasSize(1);
-			assertThat(service.getFiles().getFirst().getId()).isEqualTo(uploadedInputFile);
+			assertThat(service.getFiles()).containsExactly(uploadedInputFile);
 		});
-	}
-
-	@Test
-	void toModelIdsTest() {
-		var id1 = UUID.randomUUID();
-		var id2 = UUID.randomUUID();
-		var ids = List.of(id1, id2);
-
-		var modelIds = EneoMapper.toModelIds(ids);
-
-		assertThat(modelIds).isNotNull().hasSize(2)
-			.extracting("id")
-			.containsExactlyInAnyOrder(id1, id2);
 	}
 
 	@Test
@@ -49,8 +38,7 @@ class EneoMapperTest {
 
 		assertThat(askAssistant).isNotNull().satisfies(assistant -> {
 			assertThat(assistant.getQuestion()).isEqualTo(question);
-			assertThat(assistant.getFiles()).hasSize(1);
-			assertThat(assistant.getFiles().getFirst().getId()).isEqualTo(uploadedInputFile);
+			assertThat(assistant.getFiles()).containsExactly(uploadedInputFile);
 		});
 	}
 
@@ -79,6 +67,69 @@ class EneoMapperTest {
 			assertThat(res.sessionId()).isNull();
 			assertThat(res.answer()).isEqualTo(output);
 		});
+	}
+
+	@Test
+	void toResponseFromServiceOutputWithMapTest() {
+		final var output = new LinkedHashMap<String, Object>();
+		output.put("key", "value");
+		output.put("number", 42);
+		final var serviceOutput = new ServiceOutput().output(output);
+
+		final var response = EneoMapper.toResponse(serviceOutput);
+
+		assertThat(response).isNotNull().satisfies(res -> {
+			assertThat(res.sessionId()).isNull();
+			assertThat(res.answer()).isEqualTo("{\"key\":\"value\",\"number\":42}");
+		});
+	}
+
+	@Test
+	void toResponseFromServiceOutputWithListTest() {
+		final var output = List.of("item1", "item2", "item3");
+		final var serviceOutput = new ServiceOutput().output(output);
+
+		final var response = EneoMapper.toResponse(serviceOutput);
+
+		assertThat(response).isNotNull().satisfies(res -> {
+			assertThat(res.sessionId()).isNull();
+			assertThat(res.answer()).isEqualTo("[\"item1\",\"item2\",\"item3\"]");
+		});
+	}
+
+	@Test
+	void toResponseFromServiceOutputWithBooleanTest() {
+		final var serviceOutput = new ServiceOutput().output(true);
+
+		final var response = EneoMapper.toResponse(serviceOutput);
+
+		assertThat(response).isNotNull().satisfies(res -> {
+			assertThat(res.sessionId()).isNull();
+			assertThat(res.answer()).isEqualTo("true");
+		});
+	}
+
+	@Test
+	void toResponseFromServiceOutputWithNullTest() {
+		final var serviceOutput = new ServiceOutput().output(null);
+
+		final var response = EneoMapper.toResponse(serviceOutput);
+
+		assertThat(response).isNotNull().satisfies(res -> {
+			assertThat(res.sessionId()).isNull();
+			assertThat(res.answer()).isNull();
+		});
+	}
+
+	@Test
+	void toResponseFromServiceOutputWithUnserializableObjectThrowsException() {
+		final var circularMap = new LinkedHashMap<String, Object>();
+		circularMap.put("self", Collections.unmodifiableMap(circularMap));
+		final var serviceOutput = new ServiceOutput().output(circularMap);
+
+		assertThatExceptionOfType(RuntimeException.class)
+			.isThrownBy(() -> EneoMapper.toResponse(serviceOutput))
+			.withMessage("Internal Server Error: Failed to serialize ServiceOutput to JSON string");
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/ai/flow/integration/eneo/EneoServiceTest.java
+++ b/src/test/java/se/sundsvall/ai/flow/integration/eneo/EneoServiceTest.java
@@ -4,7 +4,6 @@ import generated.eneo.ai.AppRunPublic;
 import generated.eneo.ai.AskAssistant;
 import generated.eneo.ai.AskResponse;
 import generated.eneo.ai.FilePublic;
-import generated.eneo.ai.ModelId;
 import generated.eneo.ai.RunAppRequest;
 import generated.eneo.ai.RunService;
 import generated.eneo.ai.ServiceOutput;
@@ -62,7 +61,7 @@ class EneoServiceTest {
 		final var uploadedInputFilesInUseInfo = "someInfo";
 		final var askAssistantRequest = new AskAssistant()
 			.question(uploadedInputFilesInUseInfo)
-			.files(uploadedInputFilesInUse.stream().map(id -> new ModelId().id(id)).toList());
+			.files(uploadedInputFilesInUse);
 		final var sessionId = UUID.randomUUID();
 		final var answer = "someAnswer";
 


### PR DESCRIPTION
Updates the Eneo OpenAPI spec to v1.2. AskAssistant.files and RunService.files are now raw UUIDs (was ModelId), and ServiceOutput.output is polymorphic (string/json/list/boolean), so non-String values are serialized to JSON. RunAppRequest still uses ModelId.

Restricts model generation to the schemas actually consumed and maps unused transitive refs to java.lang.Object so the generator emits valid code.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
